### PR TITLE
fix: resolve stale frame and string method lookup in func-eval (#7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ All commands must be run from the repository root.
 ```bash
 dotnet build debugger/DnD.slnx
 dotnet test debugger/tests/DnD.Core.Tests           # Unit tests (fast, ~1s)
-dotnet test debugger/tests/DnD.Host.Tests           # E2E tests (slow, ~3min, spawns real debugger processes)
+dotnet test debugger/tests/DnD.Host.Tests           # Integration tests (slow, ~3min, spawns real debugger processes)
 ```
 
 ### TypeScript MCP server

--- a/debugger/src/DnD.Core/DebuggerEngine.cs
+++ b/debugger/src/DnD.Core/DebuggerEngine.cs
@@ -429,10 +429,13 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
         _currentState.EnsureStopped();
         var session = RequireSession();
 
-        var frame = (request.FrameId.HasValue && session.FrameMap.TryGetValue(request.FrameId.Value, out var f)
-            ? f
-            : session.FrameMap.GetValueOrDefault(0)) ?? throw new LocalRpcException("No frame available for evaluation")
+        var frameId = request.FrameId ?? 0;
+        CorDebugILFrame GetCurrentFrame() =>
+            (session.FrameMap.TryGetValue(frameId, out var current) ? current : null)
+            ?? throw new LocalRpcException("No frame available for evaluation")
             { ErrorCode = ErrorCodes.EvaluationFailed };
+
+        var frame = GetCurrentFrame();
         var module = frame.Function.Module;
         var reader = GetSymbolReader(module, session);
         var exVal = GetCurrentExceptionValue(session);
@@ -454,7 +457,7 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
             var ast = ExpressionParser.Parse(request.Expression);
             var thread = session.StoppedThread ?? throw new LocalRpcException("No thread available for evaluation")
             { ErrorCode = ErrorCodes.EvaluationFailed };
-            var funcEval = new FuncEvalEvaluator(this, thread, frame, reader, session.VariableStore, exVal, session.LastReturnValue);
+            var funcEval = new FuncEvalEvaluator(this, thread, GetCurrentFrame, reader, session.VariableStore, exVal, session.LastReturnValue);
             return await funcEval.EvaluateAsync(ast);
         }
         catch (FormatException ex)

--- a/debugger/src/DnD.Core/Inspection/FuncEvalEvaluator.cs
+++ b/debugger/src/DnD.Core/Inspection/FuncEvalEvaluator.cs
@@ -24,17 +24,19 @@ public class FuncEvalEvaluator
 {
     private readonly IEvalExecutor _evalExecutor;
     private readonly CorDebugThread _thread;
-    private readonly CorDebugILFrame _frame;
+    private readonly Func<CorDebugILFrame> _frameAccessor;
     private readonly ISymbolReader? _reader;
     private readonly VariableStore _store;
     private readonly CorDebugValue? _exceptionValue;
     private readonly CorDebugValue? _returnValue;
     private readonly ValueReader _valueReader = new();
 
+    private CorDebugILFrame Frame => _frameAccessor();
+
     public FuncEvalEvaluator(
         IEvalExecutor evalExecutor,
         CorDebugThread thread,
-        CorDebugILFrame frame,
+        Func<CorDebugILFrame> frameAccessor,
         ISymbolReader? reader,
         VariableStore store,
         CorDebugValue? exceptionValue = null,
@@ -42,7 +44,7 @@ public class FuncEvalEvaluator
     {
         _evalExecutor = evalExecutor;
         _thread = thread;
-        _frame = frame;
+        _frameAccessor = frameAccessor;
         _reader = reader;
         _store = store;
         _exceptionValue = exceptionValue;
@@ -108,7 +110,7 @@ public class FuncEvalEvaluator
         // Delegate to SimpleEvaluator's variable resolution logic
         if (name == "this")
         {
-            try { return _frame.GetArgument(0); }
+            try { return Frame.GetArgument(0); }
             catch { return null; }
         }
 
@@ -116,14 +118,14 @@ public class FuncEvalEvaluator
         {
             try
             {
-                var ipResult = _frame.IP;
+                var ipResult = Frame.IP;
                 var ilOffset = (int)ipResult.pnOffset;
-                var locals = _reader.GetLocalVariables((int)_frame.Function.Token, ilOffset);
+                var locals = _reader.GetLocalVariables((int)Frame.Function.Token, ilOffset);
                 foreach (var local in locals)
                 {
                     if (local.Name == name)
                     {
-                        try { return _frame.GetLocalVariable(local.SlotIndex); }
+                        try { return Frame.GetLocalVariable(local.SlotIndex); }
                         catch { }
                     }
                 }
@@ -134,9 +136,9 @@ public class FuncEvalEvaluator
         // Look up parameter by name from metadata
         try
         {
-            var module = _frame.Function.Module;
+            var module = Frame.Function.Module;
             var import = module.GetMetaDataInterface<MetaDataImport>();
-            var methodToken = (mdMethodDef)_frame.Function.Token;
+            var methodToken = (mdMethodDef)Frame.Function.Token;
             var methodProps = import.GetMethodProps(methodToken);
             bool isStatic = methodProps.pdwAttr.HasFlag(CorMethodAttr.mdStatic);
             var enumHandle = IntPtr.Zero;
@@ -155,7 +157,7 @@ public class FuncEvalEvaluator
                                 ? props.pulSequence - 1
                                 : props.pulSequence;
                             if (enumHandle != IntPtr.Zero) import.CloseEnum(enumHandle);
-                            try { return _frame.GetArgument(paramArgIndex); }
+                            try { return Frame.GetArgument(paramArgIndex); }
                             catch { return null; }
                         }
                     }
@@ -172,7 +174,7 @@ public class FuncEvalEvaluator
 
         if (name.StartsWith("arg") && int.TryParse(name[3..], out var argIndex))
         {
-            try { return _frame.GetArgument(argIndex); }
+            try { return Frame.GetArgument(argIndex); }
             catch { return null; }
         }
 
@@ -260,19 +262,24 @@ public class FuncEvalEvaluator
         var raw = obj;
         obj = Dereference(obj);
 
+        CorDebugFunction? method = null;
+
         if (obj is CorDebugObjectValue objVal)
+            method = MetadataHelper.FindMethodByName(objVal, methodName, args.Length);
+
+        // Fallback for non-object values (e.g., CorDebugStringValue):
+        // use ICorDebugValue2.GetExactType to walk the type hierarchy.
+        method ??= MetadataHelper.FindMethodByExactType(obj, methodName, args.Length);
+
+        if (method != null)
         {
-            var method = MetadataHelper.FindMethodByName(objVal, methodName, args.Length);
-            if (method != null)
+            var allArgs = new CorDebugValue[args.Length + 1];
+            allArgs[0] = raw;
+            Array.Copy(args, 0, allArgs, 1, args.Length);
+            return await _evalExecutor.ExecuteEvalAsync(eval =>
             {
-                var allArgs = new CorDebugValue[args.Length + 1];
-                allArgs[0] = raw;
-                Array.Copy(args, 0, allArgs, 1, args.Length);
-                return await _evalExecutor.ExecuteEvalAsync(eval =>
-                {
-                    CallFunction(eval, method, allArgs);
-                }, _thread);
-            }
+                CallFunction(eval, method, allArgs);
+            }, _thread);
         }
 
         throw MakeError($"Method '{methodName}' not found");

--- a/debugger/src/DnD.Core/Inspection/MetadataHelper.cs
+++ b/debugger/src/DnD.Core/Inspection/MetadataHelper.cs
@@ -53,6 +53,41 @@ public static class MetadataHelper
     }
 
     /// <summary>
+    /// Find a method by name and argument count on any value's exact runtime type.
+    /// Uses ICorDebugValue2.GetExactType to walk the type hierarchy.
+    /// Works for CorDebugStringValue and other non-object value types.
+    /// </summary>
+    public static CorDebugFunction? FindMethodByExactType(CorDebugValue value, string methodName, int argCount)
+    {
+        try
+        {
+            var val2 = (ICorDebugValue2)value.Raw;
+            val2.GetExactType(out var currentType);
+
+            int depth = 0;
+            while (currentType != null && depth++ < 20)
+            {
+                ICorDebugClass? cls;
+                try
+                {
+                    currentType.GetClass(out cls);
+                    if (cls == null) break;
+                }
+                catch { break; }
+
+                var clsWrapper = new CorDebugClass(cls);
+                var result = FindMethodInClass(clsWrapper, methodName, argCount);
+                if (result != null) return result;
+
+                try { currentType.GetBase(out currentType); }
+                catch { break; }
+            }
+        }
+        catch { }
+        return null;
+    }
+
+    /// <summary>
     /// Find a method by name on a given class (CorDebugClass), searching the class token.
     /// </summary>
     public static CorDebugFunction? FindMethodInClass(CorDebugClass classType, string methodName, int argCount)

--- a/docs/mcp-integration-test-plan.md
+++ b/docs/mcp-integration-test-plan.md
@@ -55,6 +55,8 @@ Confirm that `dnd-debugger` appears with 20 tools listed.
 
 Each scenario issues instructions in the Claude Code chat and verifies MCP tool call results.
 
+**Important**: Scenarios 2.10 and 2.11 test the `not-started` state and must be run **first** after a fresh MCP server connection (restart Claude Code). Once any `launch` has been called, the state transitions to `exited` after termination, not back to `not-started`.
+
 ### 2.1 Basic: Process Launch and Termination
 
 **Purpose**: Verify launch / terminate / output file behavior
@@ -72,11 +74,11 @@ Each scenario issues instructions in the Claude Code chat and verifies MCP tool 
 
 ### 2.2 Breakpoints + Stopping
 
-**Purpose**: Verify setBreakpoint -> launch -> stop -> display format
+**Purpose**: Verify setBreakpoint -> launch -> stop -> display format + removeBreakpoint
 
 **Steps**:
-1. `setBreakpoint` at BreakpointTest Program.cs:3
-   - Expected: `Breakpoint 1 set at ...Program.cs:3 (pending — will activate when code is loaded)`
+1. `setBreakpoint` at BreakpointTest Program.cs:7
+   - Expected: `Breakpoint 1 set at ...Program.cs:7 (pending — will activate when code is loaded)`
 2. `getBreakpoints` to check BP list
    - Expected: 1 entry with `(pending)` display
 3. `launch` BreakpointTest -> `continue`
@@ -84,17 +86,32 @@ Each scenario issues instructions in the Claude Code chat and verifies MCP tool 
 4. `getStackTrace`
    - Expected: Stack frame shows module name `[BreakpointTest.dll]`
 5. `getVariables` should include `a`, `b`
+6. `removeBreakpoint` with breakpointId=1 (while stopped)
+   - Expected: `Breakpoint 1 removed`
+7. `getBreakpoints` to verify removal
+   - Expected: `No breakpoints set`
+
+**Note**: `removeBreakpoint` must be called while the debugger connection is active (before `terminate`). Calling it after `terminate` will return an error.
 
 ### 2.3 Stepping
 
 **Purpose**: Verify stepOver / stepIn / stepOut behavior
 
-**Steps**:
+**Steps (stepOver)**:
 1. Launch VariablesTest -> stops at Debugger.Break()
    - Expected: `Stopped: pause`
 2. Execute `stepOver` several times
    - Expected: Each time `Stopped: step` + line number advances
 3. Stack trace line numbers should be monotonically increasing
+4. `terminate` to exit
+
+**Steps (stepIn)**:
+5. `setBreakpoint` at BreakpointTest Program.cs:12 (`var result = Add(1, 2);`)
+6. `launch` BreakpointTest -> stops at breakpoint
+   - Expected: `Stopped: breakpoint #1` at Program.cs:12
+7. Execute `stepIn`
+   - Expected: `Stopped: step` at Program.Add (Program.cs:6 or :7) — entered the function
+8. `terminate` to exit
 
 ### 2.4 Variable Inspection
 
@@ -211,8 +228,10 @@ Each scenario issues instructions in the Claude Code chat and verifies MCP tool 
 
 **Purpose**: Verify getState tool behavior
 
+**Prerequisite**: This scenario must be run **first** after a fresh MCP server connection to test the `not-started` state. Once any `launch` has been called, the state after `terminate` is `exited`, not `not-started`.
+
 **Steps**:
-1. Call `getState` before launch
+1. Call `getState` before any launch (fresh MCP server session)
    - Expected: `State: not-started`
 2. Launch VariablesTest -> stops at Debugger.Break()
 3. Call `getState`
@@ -231,8 +250,10 @@ Each scenario issues instructions in the Claude Code chat and verifies MCP tool 
 
 **Purpose**: Verify waitForStop tool behavior across all states
 
+**Prerequisite**: Step 1 must be run **before any `launch`** in the MCP server session (fresh connection). After a process has exited, `waitForStop` returns exit info instead of an error.
+
 **Steps**:
-1. Call `waitForStop` before launch
+1. Call `waitForStop` before any launch (fresh MCP server session)
    - Expected: Error — `No process running. Call launch or attach first.`
 2. Launch VariablesTest -> stops at Debugger.Break()
 3. Call `waitForStop` (already stopped)


### PR DESCRIPTION
## Summary

- Fix `Variable not found` error when evaluating expressions that require variable resolution after func-eval (e.g., `obj.Name.Contains(greeting)`)
- Fix `Method not found` error when calling methods on non-`CorDebugObjectValue` types (e.g., `string.Contains`)
- Update E2E test plan with missing test steps and execution order constraints

Closes #7

## Root Cause

`FuncEvalEvaluator` captured `CorDebugILFrame` as a value at construction time. When func-eval executed (`process.Continue(false)`), ICorDebug neutered the original frame. `HandleEvalResult` called `RefreshFrameMap` which repopulated `session.FrameMap` with fresh frames, but `FuncEvalEvaluator._frame` still held the stale reference. Subsequent variable resolution failed silently via `catch {}` blocks and fell through to `Variable 'xxx' not found`.

Additionally, `CallMethodAsync` only searched for methods on `CorDebugObjectValue`, but func-eval results for strings are returned as `CorDebugStringValue`, causing `Method 'Contains' not found`.

## Changes

- **`FuncEvalEvaluator.cs`**: Change `_frame` from `CorDebugILFrame` to `Func<CorDebugILFrame>` so each variable resolution fetches the current frame from `session.FrameMap`. Also update `CallMethodAsync` to fall back to `FindMethodByExactType` for non-object values.
- **`DebuggerEngine.cs`**: Pass a `GetCurrentFrame` lambda to `FuncEvalEvaluator` instead of a captured frame value.
- **`MetadataHelper.cs`**: Add `FindMethodByExactType` that uses `ICorDebugValue2.GetExactType()` to walk the type hierarchy, enabling method lookup on `CorDebugStringValue` and other non-object value types.
- **`CLAUDE.md`**: Fix terminology: "E2E tests" → "Integration tests" for `DnD.Host.Tests`.
- **`docs/mcp-integration-test-plan.md`**: Add `removeBreakpoint` steps to 2.2, `stepIn` steps to 2.3, execution order prerequisites for 2.10/2.11 (`not-started` state requires fresh MCP session).

## Test Plan

- [x] `dotnet build debugger/DnD.slnx` — 0 errors, 0 warnings
- [x] `dotnet test debugger/tests/DnD.Core.Tests` — 206 passed
- [x] `dotnet test debugger/tests/DnD.Host.Tests` — 283 passed (including `Evaluate_ChainedPropertyThenLocalInArg`)
- [x] MCP E2E test scenarios 2.1–2.19 — all pass

## Commits

- `2d98868` fix: resolve stale frame and string method lookup in func-eval (#7)
- `bf8cd98` docs: update E2E test plan with execution order constraints and missing steps