### PR TITLE
fix: buffer module loads during Launch()-to-session race window (#9)

### DIFF
--- a/debugger/src/DnD.Core/DebuggerEngine.cs
+++ b/debugger/src/DnD.Core/DebuggerEngine.cs
@@ -16,6 +16,10 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
     private readonly IProcessLauncher _launcher;
     private readonly object _lock = new();
 
+    // Module-load buffering for race between Launch() and _session assignment
+    private readonly object _moduleBufferLock = new();
+    private List<CorDebugModule>? _moduleBuffer;
+
     // Session-crossing state
     private readonly BreakpointManager _breakpointManager = new();
 
@@ -41,6 +45,9 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
     {
         var handler = new ManagedCallbackHandler();
         ApplyExceptionBreakpointSettings(handler);
+
+        lock (_moduleBufferLock) { _moduleBuffer = new List<CorDebugModule>(); }
+
         WireCallbackEvents(handler);
 
         var result = _launcher.Launch(
@@ -52,7 +59,17 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
             StopAtEntry = request.StopAtEntry,
             ProgramPath = Path.GetFullPath(request.Program)
         };
-        _session = session;
+        Volatile.Write(ref _session, session);
+
+        // Replay buffered module loads, then switch to direct mode
+        List<CorDebugModule> buffered;
+        lock (_moduleBufferLock)
+        {
+            buffered = _moduleBuffer ?? new();
+            _moduleBuffer = null;
+        }
+        foreach (var module in buffered)
+            HandleModuleLoaded(session, module, handler);
 
         if (result.StandardOutput != null)
             StartOutputReader(result.StandardOutput, OutputCategory.Stdout);
@@ -66,12 +83,26 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
     {
         var handler = new ManagedCallbackHandler();
         ApplyExceptionBreakpointSettings(handler);
+
+        lock (_moduleBufferLock) { _moduleBuffer = new List<CorDebugModule>(); }
+
         WireCallbackEvents(handler);
 
         var result = _launcher.Attach(request.ProcessId, handler.Callback);
 
         var session = new DebugSession(result.CorDebug, result.Process, handler);
-        _session = session;
+        Volatile.Write(ref _session, session);
+
+        // Replay buffered module loads, then switch to direct mode
+        List<CorDebugModule> buffered;
+        lock (_moduleBufferLock)
+        {
+            buffered = _moduleBuffer ?? new();
+            _moduleBuffer = null;
+        }
+        foreach (var module in buffered)
+            HandleModuleLoaded(session, module, handler);
+
         return session;
     }
 
@@ -81,7 +112,7 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
     void ISessionContext.EndSession()
     {
         var session = _session;
-        _session = null;
+        Volatile.Write(ref _session, null);
         if (session != null)
         {
             _breakpointManager.RevertAllToPending();
@@ -707,8 +738,18 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
     {
         handler.OnStopped += (thread, reason, description) =>
         {
-            var session = _session;
-            if (session == null) return;
+            var session = Volatile.Read(ref _session);
+            if (session == null)
+            {
+                // Wait for _session assignment (Launch() return → assignment window, typically microseconds)
+                var sw = new SpinWait();
+                for (int i = 0; i < 200 && session == null; i++)
+                {
+                    sw.SpinOnce();
+                    session = Volatile.Read(ref _session);
+                }
+                if (session == null) return;
+            }
 
             // Quick hit-count check before full state setup
             if (reason == StopReason.Breakpoint && handler.LastHitBreakpoint != null)
@@ -790,29 +831,18 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
 
         handler.OnModuleLoaded += (module) =>
         {
-            var session = _session;
-            if (session == null) return;
-
-            var moduleName = module.Name;
-            if (string.IsNullOrEmpty(moduleName)) return;
-
-            var reader = Symbols.SymbolReaderFactory.Create(moduleName);
-            session.Modules[moduleName] = (module, reader);
-            _breakpointManager.OnModuleLoaded(moduleName, module, reader);
-
-            // Handle stopAtEntry: set entry breakpoint when the target module loads
-            if (session.StopAtEntry && handler.EntryBreakpoint == null && session.ProgramPath != null)
+            lock (_moduleBufferLock)
             {
-                try
+                if (_moduleBuffer != null)
                 {
-                    var normalizedModule = Path.GetFullPath(moduleName);
-                    if (string.Equals(normalizedModule, session.ProgramPath, StringComparison.OrdinalIgnoreCase))
-                    {
-                        SetEntryPointBreakpoint(module, handler);
-                    }
+                    _moduleBuffer.Add(module);
+                    return;
                 }
-                catch { }
             }
+            // Buffer disabled = _session is set
+            var session = Volatile.Read(ref _session);
+            if (session == null) return;
+            HandleModuleLoaded(session, module, handler);
         };
 
         handler.OnEvalCompleted += (thread, eval, success) =>
@@ -825,6 +855,30 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
     }
 
     // ── Private helpers ────────────────────────────────────────────────
+
+    private void HandleModuleLoaded(DebugSession session, CorDebugModule module, ManagedCallbackHandler handler)
+    {
+        var moduleName = module.Name;
+        if (string.IsNullOrEmpty(moduleName)) return;
+
+        var reader = Symbols.SymbolReaderFactory.Create(moduleName);
+        session.Modules[moduleName] = (module, reader);
+        _breakpointManager.OnModuleLoaded(moduleName, module, reader);
+
+        // Handle stopAtEntry: set entry breakpoint when the target module loads
+        if (session.StopAtEntry && handler.EntryBreakpoint == null && session.ProgramPath != null)
+        {
+            try
+            {
+                var normalizedModule = Path.GetFullPath(moduleName);
+                if (string.Equals(normalizedModule, session.ProgramPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    SetEntryPointBreakpoint(module, handler);
+                }
+            }
+            catch { }
+        }
+    }
 
     private DebugSession RequireSession()
         => _session ?? throw new InvalidOperationException("No active debug session");

--- a/debugger/tests/DnD.Core.Tests/DebuggerEngineRaceConditionTests.cs
+++ b/debugger/tests/DnD.Core.Tests/DebuggerEngineRaceConditionTests.cs
@@ -1,0 +1,229 @@
+namespace DnD.Core.Tests;
+
+using ClrDebug;
+using DnD.Core.Runtime;
+using DnD.Protocol;
+
+/// <summary>
+/// Deterministic tests for the race condition between Launch() and _session assignment.
+/// Module loads fired during Launch() must be buffered and replayed after _session is set.
+/// </summary>
+public class DebuggerEngineRaceConditionTests : IDisposable
+{
+    // Use the test assembly's own DLL as a file that definitely exists
+    private static readonly string ExistingFile =
+        typeof(DebuggerEngineRaceConditionTests).Assembly.Location;
+
+    private readonly DebuggerEngine _engine;
+    private readonly ModuleLoadDuringLaunchLauncher _launcher;
+
+    public DebuggerEngineRaceConditionTests()
+    {
+        _launcher = new ModuleLoadDuringLaunchLauncher();
+        _engine = new DebuggerEngine(_launcher);
+    }
+
+    public void Dispose() => _engine.Dispose();
+
+    /// <summary>
+    /// Verifies that a module loaded during Launch() (before _session assignment)
+    /// is properly buffered and replayed into session.Modules.
+    ///
+    /// Without the fix: OnModuleLoaded fires during Launch(), _session is null,
+    /// handler returns early → module is lost.
+    /// With the fix: module is buffered, replayed after _session assignment → registered.
+    /// </summary>
+    [Fact]
+    public async Task ModuleLoadDuringLaunch_IsBufferedAndReplayed()
+    {
+        const string moduleName = @"C:\test\TestModule.dll";
+        _launcher.ModulesToLoadDuringLaunch.Add(moduleName);
+
+        await _engine.LaunchAsync(new LaunchRequest(Program: ExistingFile));
+
+        var session = ((ISessionContext)_engine).GetSession();
+        Assert.True(session.Modules.ContainsKey(moduleName),
+            "Module loaded during Launch() should be registered in session.Modules");
+    }
+
+    /// <summary>
+    /// Verifies that multiple modules loaded during Launch() are all buffered and replayed.
+    /// Simulates corlib + framework + user modules loading before _session is set.
+    /// </summary>
+    [Fact]
+    public async Task MultipleModuleLoadsDuringLaunch_AllBufferedAndReplayed()
+    {
+        var moduleNames = new[]
+        {
+            @"C:\dotnet\corlib.dll",
+            @"C:\dotnet\System.Runtime.dll",
+            @"C:\app\UserApp.dll",
+        };
+        foreach (var name in moduleNames)
+            _launcher.ModulesToLoadDuringLaunch.Add(name);
+
+        await _engine.LaunchAsync(new LaunchRequest(Program: ExistingFile));
+
+        var session = ((ISessionContext)_engine).GetSession();
+        foreach (var name in moduleNames)
+            Assert.True(session.Modules.ContainsKey(name),
+                $"Module '{name}' loaded during Launch() should be registered");
+    }
+
+    /// <summary>
+    /// Verifies that pending breakpoints are resolved for modules loaded during Launch().
+    ///
+    /// Without the fix: module dropped → _breakpointManager.OnModuleLoaded never called
+    /// → breakpoint stays Pending.
+    /// With the fix: module replayed → OnModuleLoaded called → breakpoint resolution attempted.
+    /// </summary>
+    [Fact]
+    public async Task PendingBreakpoint_ResolvedByBufferedModuleLoad()
+    {
+        const string moduleName = @"C:\test\TestModule.dll";
+        _launcher.ModulesToLoadDuringLaunch.Add(moduleName);
+
+        // Set a breakpoint before launch — it becomes pending
+        await _engine.SetBreakpointAsync(
+            new SetBreakpointRequest(File: @"C:\test\Program.cs", Line: 10));
+
+        await _engine.LaunchAsync(new LaunchRequest(Program: ExistingFile));
+
+        // Verify OnModuleLoaded was called for the buffered module
+        // (breakpoint won't verify without a real PDB, but the module must be registered)
+        var session = ((ISessionContext)_engine).GetSession();
+        Assert.True(session.Modules.ContainsKey(moduleName));
+    }
+
+    // ── Mock IProcessLauncher ───────────────────────────────────────────
+
+    private class ModuleLoadDuringLaunchLauncher : IProcessLauncher
+    {
+        public List<string> ModulesToLoadDuringLaunch { get; } = new();
+
+        public LaunchResult Launch(
+            string program, string[]? args, string? cwd,
+            Dictionary<string, string>? env,
+            CorDebugManagedCallback callback)
+        {
+            // Fire LoadModule for each module DURING Launch(), before _session is assigned.
+            // This deterministically reproduces the race condition.
+            var mcb = (ICorDebugManagedCallback)callback;
+            var mockAD = new MockCorDebugAppDomain();
+            foreach (var name in ModulesToLoadDuringLaunch)
+                mcb.LoadModule(mockAD, new MockCorDebugModule(name));
+
+            return new LaunchResult(
+                new CorDebug(new MockCorDebug()),
+                new CorDebugProcess(new MockCorDebugProcess()));
+        }
+
+        public LaunchResult Attach(int processId, CorDebugManagedCallback callback)
+            => throw new NotImplementedException();
+    }
+
+    // ── Mock COM implementations ────────────────────────────────────────
+
+    private class MockCorDebugModule : ICorDebugModule
+    {
+        private readonly string _name;
+        public MockCorDebugModule(string name) => _name = name;
+
+        public HRESULT GetName(int cchName, out int pcchName, char[]? szName)
+        {
+            pcchName = _name.Length + 1;
+            if (szName != null)
+                _name.AsSpan().CopyTo(szName.AsSpan(0, Math.Min(_name.Length, szName.Length)));
+            return HRESULT.S_OK;
+        }
+
+        public HRESULT GetProcess(out ICorDebugProcess ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetBaseAddress(out CORDB_ADDRESS pAddress) { pAddress = default; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetAssembly(out ICorDebugAssembly ppAssembly) { ppAssembly = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnableJITDebugging(bool bTrackJITInfo, bool bAllowJitOpts) => HRESULT.E_NOTIMPL;
+        public HRESULT EnableClassLoadCallbacks(bool bClassLoadCallbacks) => HRESULT.E_NOTIMPL;
+        public HRESULT GetFunctionFromToken(mdMethodDef methodDef, out ICorDebugFunction ppFunction) { ppFunction = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetFunctionFromRVA(long rva, out ICorDebugFunction ppFunction) { ppFunction = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetClassFromToken(mdTypeDef typeDef, out ICorDebugClass ppClass) { ppClass = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT CreateBreakpoint(out ICorDebugModuleBreakpoint ppBreakpoint) { ppBreakpoint = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetEditAndContinueSnapshot(out ICorDebugEditAndContinueSnapshot ppEditAndContinueSnapshot) { ppEditAndContinueSnapshot = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetMetaDataInterface(in Guid riid, out object ppObj) { ppObj = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetToken(out mdModule pToken) { pToken = default; return HRESULT.E_NOTIMPL; }
+        public HRESULT IsDynamic(out int pDynamic) { pDynamic = 0; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetGlobalVariableValue(mdFieldDef fieldDef, out ICorDebugValue ppValue) { ppValue = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetSize(out int pcBytes) { pcBytes = 0; return HRESULT.E_NOTIMPL; }
+        public HRESULT IsInMemory(out int pInMemory) { pInMemory = 0; return HRESULT.E_NOTIMPL; }
+    }
+
+    private class MockCorDebugAppDomain : ICorDebugAppDomain
+    {
+        // ICorDebugAppDomain
+        public HRESULT GetProcess(out ICorDebugProcess ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateAssemblies(out ICorDebugAssemblyEnum ppAssemblies) { ppAssemblies = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetModuleFromMetaDataInterface(object pIMetaData, out ICorDebugModule ppModule) { ppModule = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateBreakpoints(out ICorDebugBreakpointEnum ppBreakpoints) { ppBreakpoints = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateSteppers(out ICorDebugStepperEnum ppSteppers) { ppSteppers = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT IsAttached(out bool pbAttached) { pbAttached = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetName(int cchName, out int pcchName, char[]? szName) { pcchName = 0; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetObject(out ICorDebugValue ppObject) { ppObject = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT Attach() => HRESULT.S_OK;
+        public HRESULT GetID(out int pId) { pId = 1; return HRESULT.S_OK; }
+        // ICorDebugController
+        public HRESULT Stop(int dwTimeoutIgnored) => HRESULT.S_OK;
+        public HRESULT Continue(bool fIsOutOfBand) => HRESULT.S_OK;
+        public HRESULT IsRunning(out bool pbRunning) { pbRunning = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT HasQueuedCallbacks(ICorDebugThread? pThread, out bool pbQueued) { pbQueued = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateThreads(out ICorDebugThreadEnum ppThreads) { ppThreads = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT SetAllThreadsDebugState(CorDebugThreadState state, ICorDebugThread? pExceptThisThread) => HRESULT.E_NOTIMPL;
+        public HRESULT Detach() => HRESULT.S_OK;
+        public HRESULT Terminate(int exitCode) => HRESULT.S_OK;
+        public HRESULT CanCommitChanges(int cSnapshots, ref ICorDebugEditAndContinueSnapshot pSnapshots, out ICorDebugErrorInfoEnum pError) { pError = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT CommitChanges(int cSnapshots, ref ICorDebugEditAndContinueSnapshot pSnapshots, out ICorDebugErrorInfoEnum pError) { pError = null!; return HRESULT.E_NOTIMPL; }
+    }
+
+    private class MockCorDebug : ICorDebug
+    {
+        public HRESULT Initialize() => HRESULT.S_OK;
+        public HRESULT Terminate() => HRESULT.S_OK;
+        public HRESULT SetManagedHandler(ICorDebugManagedCallback pCallback) => HRESULT.S_OK;
+        public HRESULT SetUnmanagedHandler(ICorDebugUnmanagedCallback pCallback) => HRESULT.E_NOTIMPL;
+        public HRESULT CreateProcess(string lpApplicationName, string lpCommandLine, ref SECURITY_ATTRIBUTES lpProcessAttributes, ref SECURITY_ATTRIBUTES lpThreadAttributes, bool bInheritHandles, CreateProcessFlags dwCreationFlags, IntPtr lpEnvironment, string lpCurrentDirectory, ref STARTUPINFOW lpStartupInfo, ref PROCESS_INFORMATION lpProcessInformation, CorDebugCreateProcessFlags debuggingFlags, out ICorDebugProcess ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT DebugActiveProcess(int id, bool win32Attach, out ICorDebugProcess ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateProcesses(out ICorDebugProcessEnum ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetProcess(int dwProcessId, out ICorDebugProcess ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT CanLaunchOrAttach(int dwProcessId, int win32DebuggingEnabled) => HRESULT.E_NOTIMPL;
+    }
+
+    private class MockCorDebugProcess : ICorDebugProcess
+    {
+        // ICorDebugProcess
+        public HRESULT GetID(out int pdwProcessId) { pdwProcessId = 9999; return HRESULT.S_OK; }
+        public HRESULT GetHandle(out IntPtr phProcessHandle) { phProcessHandle = IntPtr.Zero; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetThread(int dwThreadId, out ICorDebugThread ppThread) { ppThread = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateObjects(out ICorDebugObjectEnum ppObjects) { ppObjects = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT IsTransitionStub(CORDB_ADDRESS address, out bool pbTransitionStub) { pbTransitionStub = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT IsOSSuspended(int threadID, out bool pbSuspended) { pbSuspended = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetThreadContext(int threadID, int contextSize, IntPtr context) => HRESULT.E_NOTIMPL;
+        public HRESULT SetThreadContext(int threadID, int contextSize, IntPtr context) => HRESULT.E_NOTIMPL;
+        public HRESULT ReadMemory(CORDB_ADDRESS address, int size, IntPtr buffer, out int read) { read = 0; return HRESULT.E_NOTIMPL; }
+        public HRESULT WriteMemory(CORDB_ADDRESS address, int size, IntPtr buffer, out int written) { written = 0; return HRESULT.E_NOTIMPL; }
+        public HRESULT ClearCurrentException(int threadID) => HRESULT.E_NOTIMPL;
+        public HRESULT EnableLogMessages(bool fOnOff) => HRESULT.E_NOTIMPL;
+        public HRESULT ModifyLogSwitch(string pLogSwitchName, int lLevel) => HRESULT.E_NOTIMPL;
+        public HRESULT EnumerateAppDomains(out ICorDebugAppDomainEnum ppAppDomains) { ppAppDomains = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetObject(out ICorDebugValue ppObject) { ppObject = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT ThreadForFiberCookie(int fiberCookie, out ICorDebugThread ppThread) { ppThread = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetHelperThreadID(out int pThreadID) { pThreadID = 0; return HRESULT.E_NOTIMPL; }
+        // ICorDebugController
+        public HRESULT Stop(int dwTimeoutIgnored) => HRESULT.S_OK;
+        public HRESULT Continue(bool fIsOutOfBand) => HRESULT.S_OK;
+        public HRESULT IsRunning(out bool pbRunning) { pbRunning = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT HasQueuedCallbacks(ICorDebugThread? pThread, out bool pbQueued) { pbQueued = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateThreads(out ICorDebugThreadEnum ppThreads) { ppThreads = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT SetAllThreadsDebugState(CorDebugThreadState state, ICorDebugThread? pExceptThisThread) => HRESULT.E_NOTIMPL;
+        public HRESULT Detach() => HRESULT.S_OK;
+        public HRESULT Terminate(int exitCode) => HRESULT.S_OK;
+        public HRESULT CanCommitChanges(int cSnapshots, ref ICorDebugEditAndContinueSnapshot pSnapshots, out ICorDebugErrorInfoEnum pError) { pError = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT CommitChanges(int cSnapshots, ref ICorDebugEditAndContinueSnapshot pSnapshots, out ICorDebugErrorInfoEnum pError) { pError = null!; return HRESULT.E_NOTIMPL; }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #9 — Debugger events intermittently not caught when debugging net10.0 targets.

`OnModuleLoaded` callbacks fired between `_launcher.Launch()` return and `_session` assignment were silently dropped because `_session` was still null. This caused loss of module registrations, pending breakpoint resolution, and stopAtEntry breakpoints.

## Root Cause

Race condition in `DebuggerEngine.CreateLaunchSession()` event propagation path:

1. `_launcher.Launch()` calls `DebugActiveProcess()` internally
2. ICorDebug starts firing events on background callback thread
3. `Launch()` returns
4. **Main thread**: `new DebugSession(...)` → `_session = session`
5. **Callback thread**: `OnModuleLoaded` fires → reads `_session`

Race occurs between steps 4-5. The window is typically microseconds, but thread scheduling and runtime startup speed (especially .NET 10 Preview) can occasionally allow callbacks to enter the window.

## Changes

### `DebuggerEngine.cs`

- **OnModuleLoaded buffering**: Accumulate module loads in `_moduleBuffer` while `_session` is unset, then replay after assignment
- **OnStopped SpinWait**: Safety net — spin wait (200 iterations) when `_session` is null, since OnStopped does not call ContinueProcess and is safe to block
- **Volatile.Write/Read**: Ensure cross-thread visibility of `_session`
- **HandleModuleLoaded method extraction**: Extract `OnModuleLoaded` handler body into a standalone method called from both buffer replay and direct mode

### `DebuggerEngineRaceConditionTests.cs` (new)

Deterministic unit tests using mock COM objects (`ICorDebugModule`, `ICorDebugProcess`, `ICorDebug`, `ICorDebugAppDomain`). The mock `IProcessLauncher.Launch()` synchronously fires `ICorDebugManagedCallback.LoadModule()`, guaranteeing the module load occurs before `_session` assignment.

| Test | Assertion |
|---|---|
| `ModuleLoadDuringLaunch_IsBufferedAndReplayed` | Module loaded during Launch() is registered in `session.Modules` |
| `MultipleModuleLoadsDuringLaunch_AllBufferedAndReplayed` | All modules (corlib etc.) are buffered and replayed |
| `PendingBreakpoint_ResolvedByBufferedModuleLoad` | Pending BP resolution path is executed for buffered modules |

All 3 tests fail with fix reverted, pass with fix applied.

## Test Results

- Unit tests: 209/209 passed
- Integration tests: 283/283 passed (10 consecutive runs, 0 failures)

## Commits

- `182476c` fix: buffer module loads during Launch()-to-session race window (#9)