### PR TITLE
fix: capture stdout/stderr for .NET Framework targets (#10)

### DIFF
--- a/debugger/src/DnD.Core/Runtime/FrameworkProcessLauncher.cs
+++ b/debugger/src/DnD.Core/Runtime/FrameworkProcessLauncher.cs
@@ -1,5 +1,7 @@
 namespace DnD.Core.Runtime;
 
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
 using ClrDebug;
 
 public class FrameworkProcessLauncher : IProcessLauncher
@@ -14,23 +16,52 @@ public class FrameworkProcessLauncher : IProcessLauncher
 
         var commandLine = BuildCommandLine(program, args);
 
-        var startupInfo = new STARTUPINFOW();
-        var processInfo = new PROCESS_INFORMATION();
+        var stdoutPipe = new AnonymousPipeServerStream(PipeDirection.In, HandleInheritability.Inheritable);
+        var stderrPipe = new AnonymousPipeServerStream(PipeDirection.In, HandleInheritability.Inheritable);
 
-        var process = corDebug.CreateProcess(
-            lpApplicationName: null,
-            lpCommandLine: commandLine,
-            lpProcessAttributes: default,
-            lpThreadAttributes: default,
-            bInheritHandles: false,
-            dwCreationFlags: CreateProcessFlags.CREATE_NO_WINDOW,
-            lpEnvironment: IntPtr.Zero,
-            lpCurrentDirectory: cwd,
-            lpStartupInfo: startupInfo,
-            lpProcessInformation: ref processInfo,
-            debuggingFlags: CorDebugCreateProcessFlags.DEBUG_NO_SPECIAL_OPTIONS);
+        // NUL for stdin — mark inheritable so the child can use it
+        using var nulFile = File.OpenHandle("NUL", FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        var nulHandle = nulFile.DangerousGetHandle();
+        SetHandleInformation(nulHandle, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
 
-        return new LaunchResult(corDebug, process);
+        try
+        {
+            var startupInfo = new STARTUPINFOW();
+            startupInfo.cb = Marshal.SizeOf<STARTUPINFOW>();
+            startupInfo.dwFlags = STARTF.STARTF_USESTDHANDLES;
+            startupInfo.hStdInput = nulHandle;
+            startupInfo.hStdOutput = stdoutPipe.ClientSafePipeHandle.DangerousGetHandle();
+            startupInfo.hStdError = stderrPipe.ClientSafePipeHandle.DangerousGetHandle();
+            var processInfo = new PROCESS_INFORMATION();
+
+            var process = corDebug.CreateProcess(
+                lpApplicationName: null,
+                lpCommandLine: commandLine,
+                lpProcessAttributes: default,
+                lpThreadAttributes: default,
+                bInheritHandles: true,
+                dwCreationFlags: CreateProcessFlags.CREATE_NO_WINDOW,
+                lpEnvironment: IntPtr.Zero,
+                lpCurrentDirectory: cwd,
+                lpStartupInfo: startupInfo,
+                lpProcessInformation: ref processInfo,
+                debuggingFlags: CorDebugCreateProcessFlags.DEBUG_NO_SPECIAL_OPTIONS);
+
+            return new LaunchResult(corDebug, process, stdoutPipe, stderrPipe);
+        }
+        catch
+        {
+            stdoutPipe.Dispose();
+            stderrPipe.Dispose();
+            throw;
+        }
+        finally
+        {
+            // Close the write-end handles in our process — only the child holds them now.
+            // This ensures ReadLine() on the server end will return null when the child exits.
+            stdoutPipe.DisposeLocalCopyOfClientHandle();
+            stderrPipe.DisposeLocalCopyOfClientHandle();
+        }
     }
 
     public LaunchResult Attach(
@@ -60,6 +91,11 @@ public class FrameworkProcessLauncher : IProcessLauncher
         corDebug.Initialize();
         return corDebug;
     }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetHandleInformation(IntPtr hObject, int dwMask, int dwFlags);
+
+    private const int HANDLE_FLAG_INHERIT = 0x00000001;
 
     private static string BuildCommandLine(string program, string[]? args)
     {

--- a/debugger/tests/fixtures/ExceptionTest/Program.cs
+++ b/debugger/tests/fixtures/ExceptionTest/Program.cs
@@ -28,8 +28,7 @@ class Program
 
 /// <summary>
 /// Custom exception that extends Exception directly (not System.ArgumentException).
-/// Simulates third-party exceptions like Autodesk.Revit.Exceptions.ArgumentException
-/// that define their own ParamName property with a different inheritance chain.
+/// Simulates third-party exceptions that define their own ParamName property with a different inheritance chain.
 /// </summary>
 class CustomArgumentException : Exception
 {

--- a/docs/mcp-integration-test-plan.md
+++ b/docs/mcp-integration-test-plan.md
@@ -113,6 +113,14 @@ Each scenario issues instructions in the Claude Code chat and verifies MCP tool 
    - Expected: `Stopped: step` at Program.Add (Program.cs:6 or :7) — entered the function
 8. `terminate` to exit
 
+**Steps (stepOut)**:
+9. `setBreakpoint` at BreakpointTest Program.cs:7 (inside `Add` method)
+10. `launch` BreakpointTest -> stops at breakpoint
+    - Expected: `Stopped: breakpoint #1` at Program.cs:7 (inside Add)
+11. Execute `stepOut`
+    - Expected: `Stopped: step` at Program.Main — returned to caller (Program.cs:12 or :13)
+12. `terminate` to exit
+
 ### 2.4 Variable Inspection
 
 **Purpose**: Verify getVariables expands local variables + empty scope message
@@ -289,9 +297,13 @@ Each scenario issues instructions in the Claude Code chat and verifies MCP tool 
 **Steps**:
 1. Launch VariablesTest -> stops at Debugger.Break()
 2. `getState` to check output file path
-3. `continue` to let process exit
-4. Read the output file using the Read tool
-   - Expected: Contains `42 hello 3.14 true` (Console.WriteLine output from VariablesTest)
+3. `stepOver` twice to execute past Console.WriteLine (line 16)
+4. Read the output file using the Read tool (while still stopped)
+   - Expected: Contains `42 hello 3.14 True 42` (Console.WriteLine output from VariablesTest)
+   - This verifies FILE_SHARE_READ — the file is readable while the debugger host still holds it open
+5. `continue` to let process exit
+6. Read the output file again after exit
+   - Expected: Same content as step 4
 
 **Verification Points**:
 - Output file path is included in the launch response


### PR DESCRIPTION
## Summary

Fix empty stdout output file when launching .NET Framework (net48) targets.

`FrameworkProcessLauncher.Launch()` created the debuggee process without redirecting stdout/stderr, so `LaunchResult` had null streams and `DebuggerEngine` skipped `StartOutputReader()` entirely. This applies the same anonymous pipe redirection pattern already used by `CoreProcessLauncher`.

## Root Cause

`FrameworkProcessLauncher.cs` had three deficiencies:
- `STARTUPINFOW` used default values — no `STARTF_USESTDHANDLES`, no pipe handles
- `bInheritHandles: false` — child process could not inherit handles
- `LaunchResult` returned without streams — `DebuggerEngine.cs:74-77` skipped `StartOutputReader()`

## Changes

- Create `AnonymousPipeServerStream` for stdout/stderr
- Open NUL for stdin with inheritable handle
- Configure `STARTUPINFOW` with `STARTF_USESTDHANDLES` and pipe handles
- Set `bInheritHandles: true`
- Return pipe streams in `LaunchResult`
- Close client-side pipe handles via `DisposeLocalCopyOfClientHandle()`
- Add `SetHandleInformation` P/Invoke
- Update E2E test plan: add stepOut steps to scenario 2.3, add FILE_SHARE_READ verification to scenario 2.12

## Commits

- `7c42eb7` small fix
- `62ec950` fix: capture stdout/stderr for .NET Framework targets via anonymous pipes (#10)
- `6ebdfc2` docs: add stepOut steps and FILE_SHARE_READ verification to E2E test plan

## Test Plan

- [x] `dotnet build debugger/DnD.slnx` — build succeeds (0 warnings, 0 errors)
- [x] `dotnet test debugger/tests/DnD.Core.Tests` — 209 unit tests pass
- [x] `dotnet test debugger/tests/DnD.Host.Tests` — 282/283 integration tests pass (1 intermittent failure unrelated, tracked in #15)
- [x] MCP E2E: all 17 scenarios pass (including net48 HelloWorld stdout verification)
- [x] MCP E2E: net48 `HelloWorld.exe` output file contains `Hello, World!`

Closes #10