### PR TITLE
feat: change TFM to net8.0 for PackAsTool compatibility (#21)

### DIFF
--- a/debugger/src/DnD.Core/DnD.Core.csproj
+++ b/debugger/src/DnD.Core/DnD.Core.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/debugger/src/DnD.Core/Properties/AssemblyInfo.cs
+++ b/debugger/src/DnD.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]

--- a/debugger/src/DnD.Host/DnD.Host.csproj
+++ b/debugger/src/DnD.Host/DnD.Host.csproj
@@ -9,11 +9,27 @@
     <PackageReference Include="StreamJsonRpc" Version="2.24.84" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!-- NuGet dotnet tool packaging -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>dnd-host</ToolCommandName>
+    <PackageId>DnD.Host</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>hnmr293</Authors>
+    <Description>.NET debugger engine host for MCP (Model Context Protocol). Provides a JSON-RPC stdio server that enables LLMs to debug C# programs via ICorDebug COM API. Windows only.</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/hnmr293/DnD</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/hnmr293/DnD</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
 </Project>

--- a/debugger/src/DnD.Host/Properties/AssemblyInfo.cs
+++ b/debugger/src/DnD.Host/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]

--- a/debugger/src/DnD.Protocol/DnD.Protocol.csproj
+++ b/debugger/src/DnD.Protocol/DnD.Protocol.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/debugger/tests/DnD.Core.Tests/DnD.Core.Tests.csproj
+++ b/debugger/tests/DnD.Core.Tests/DnD.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/debugger/tests/DnD.Core.Tests/Properties/AssemblyInfo.cs
+++ b/debugger/tests/DnD.Core.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]

--- a/debugger/tests/DnD.Host.Tests/DnD.Host.Tests.csproj
+++ b/debugger/tests/DnD.Host.Tests/DnD.Host.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/debugger/tests/DnD.Host.Tests/Properties/AssemblyInfo.cs
+++ b/debugger/tests/DnD.Host.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.Versioning;
+
+[assembly: SupportedOSPlatform("windows")]


### PR DESCRIPTION
## Summary

Change all project TFMs from `net8.0-windows` to `net8.0` to enable `PackAsTool=true` for NuGet dotnet tool packaging (NETSDK1146), and add `[assembly: SupportedOSPlatform("windows")]` to suppress CA1416 warnings.

## Changes

- **TFM change**: All 5 projects (`DnD.Protocol`, `DnD.Core`, `DnD.Host`, `DnD.Core.Tests`, `DnD.Host.Tests`) changed from `net8.0-windows` to `net8.0`
- **CA1416 suppression**: Added `Properties/AssemblyInfo.cs` with `[assembly: SupportedOSPlatform("windows")]` to `DnD.Core`, `DnD.Host`, `DnD.Core.Tests`, `DnD.Host.Tests`
- **NuGet metadata**: Added `PackAsTool`, `ToolCommandName`, `PackageId`, `Version`, license, URLs, and README to `DnD.Host.csproj`

## Test results (Release build)

- Unit tests: 209/209 pass
- Integration tests: 291/291 pass
- MCP TypeScript tests: 36/36 pass
- E2E tests: 15/15 pass
- Build warnings: 0 (CA1416 resolved)
- `dotnet pack -c Release`: success (`DnD.Host.0.1.0.nupkg`)

## Commits

- `7d9e8f5` feat: change TFM to net8.0 and add PackAsTool metadata for NuGet publishing (#21)

Closes #21