### PR TITLE
feat: auto-detect dotnet global tool and update install instructions (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 /.vscode
 
 /.claude/**/*.local.json
+
+# npm (root-level local install for testing)
+/node_modules/
+/package.json
+/package-lock.json

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Add to your `.mcp.json`:
   "mcpServers": {
     "dnd": {
       "type": "stdio",
-      "command": "dnd-mcp"
+      "command": "npx",
+      "args": ["-y", "dnd-mcp"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -15,16 +15,19 @@ LLM → MCP (stdio) → TypeScript MCP Server → JSON-RPC (stdio) → C# Debugg
 ### Prerequisites
 
 - Node.js >= 18
-- .NET 8 SDK (for building from source)
+- .NET 8 SDK or later
 
 ### Install
 
 ```bash
-# Not yet published to npm registry
-# npm install -g dnd-mcp
+# Install C# debugger engine
+dotnet tool install -g DnD.Host
+
+# Install MCP server (not yet published to npm)
 git clone https://github.com/hnmr293/DnD.git
-cd DnD
-npm run build:all
+cd DnD/mcp
+npm install
+npm run build
 npm link
 ```
 
@@ -43,6 +46,8 @@ Add to your `.mcp.json`:
   }
 }
 ```
+
+The MCP server auto-detects `dnd-host` installed via `dotnet tool install`. You can override the host path by setting the `DND_HOST_PATH` environment variable in the MCP config.
 
 ## MCP Tools
 
@@ -114,7 +119,7 @@ Set `DND_HOST_PATH` to point to your local C# debugger build:
       "command": "node",
       "args": ["<path-to-repo>/mcp/dist/index.js"],
       "env": {
-        "DND_HOST_PATH": "<path-to-repo>/debugger/src/DnD.Host/bin/Debug/net8.0-windows/DnD.Host.dll"
+        "DND_HOST_PATH": "<path-to-repo>/debugger/src/DnD.Host/bin/Debug/net8.0/DnD.Host.dll"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -15,20 +15,12 @@ LLM → MCP (stdio) → TypeScript MCP Server → JSON-RPC (stdio) → C# Debugg
 ### Prerequisites
 
 - Node.js >= 18
-- .NET 8 SDK or later
+- .NET 8 runtime or later
 
 ### Install
 
 ```bash
-# Install C# debugger engine
-dotnet tool install -g DnD.Host
-
-# Install MCP server (not yet published to npm)
-git clone https://github.com/hnmr293/DnD.git
-cd DnD/mcp
-npm install
-npm run build
-npm link
+npm install -g dnd-mcp
 ```
 
 ### Configure MCP
@@ -40,14 +32,11 @@ Add to your `.mcp.json`:
   "mcpServers": {
     "dnd": {
       "type": "stdio",
-      "command": "npx",
-      "args": ["dnd-mcp"]
+      "command": "dnd-mcp"
     }
   }
 }
 ```
-
-The MCP server auto-detects `dnd-host` installed via `dotnet tool install`. You can override the host path by setting the `DND_HOST_PATH` environment variable in the MCP config.
 
 ## MCP Tools
 

--- a/mcp/src/client-manager.ts
+++ b/mcp/src/client-manager.ts
@@ -1,5 +1,5 @@
 import { resolve, dirname, join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import {
   createWriteStream,
   existsSync,
@@ -23,8 +23,13 @@ function resolveHostPath(): string {
   if (existsSync(bundledPath)) {
     return bundledPath;
   }
+  // 3. dotnet global tool
+  const toolPath = join(homedir(), ".dotnet", "tools", "dnd-host.exe");
+  if (existsSync(toolPath)) {
+    return toolPath;
+  }
   throw new Error(
-    "DnD.Host.dll not found. Set DND_HOST_PATH environment variable or install the package with bundled binaries.",
+    "DnD.Host not found. Install with: dotnet tool install -g DnD.Host, or set DND_HOST_PATH environment variable.",
   );
 }
 

--- a/mcp/src/debugger-client.ts
+++ b/mcp/src/debugger-client.ts
@@ -73,13 +73,15 @@ export class DebuggerClient extends EventEmitter<DebuggerClientEvents> {
   }
 
   async start(): Promise<void> {
-    this.process = spawn(
-      "dotnet",
-      [this.hostPath, ...this.hostArgs, "--parentPid", process.pid.toString()],
-      {
-        stdio: ["pipe", "pipe", "pipe"],
-      },
-    );
+    const isDll = this.hostPath.endsWith(".dll");
+    const command = isDll ? "dotnet" : this.hostPath;
+    const args = isDll
+      ? [this.hostPath, ...this.hostArgs, "--parentPid", process.pid.toString()]
+      : [...this.hostArgs, "--parentPid", process.pid.toString()];
+
+    this.process = spawn(command, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
 
     this.process.stderr?.on("data", (data: Buffer) => {
       // DnD.Host writes diagnostic messages to stderr

--- a/mcp/tests/debugger-client.test.ts
+++ b/mcp/tests/debugger-client.test.ts
@@ -11,7 +11,7 @@ const HOST_PATH =
   process.env.DND_HOST_PATH ??
   resolve(
     __dirname,
-    "../../debugger/src/DnD.Host/bin/Debug/net8.0-windows/DnD.Host.dll",
+    "../../debugger/src/DnD.Host/bin/Debug/net8.0/DnD.Host.dll",
   );
 
 describe("DebuggerClient (stub mode)", () => {

--- a/mcp/tests/execution.test.ts
+++ b/mcp/tests/execution.test.ts
@@ -12,7 +12,7 @@ const HOST_PATH =
   process.env.DND_HOST_PATH ??
   resolve(
     __dirname,
-    "../../debugger/src/DnD.Host/bin/Debug/net8.0-windows/DnD.Host.dll",
+    "../../debugger/src/DnD.Host/bin/Debug/net8.0/DnD.Host.dll",
   );
 
 /**


### PR DESCRIPTION
## Summary

- Add dotnet global tool (`dnd-host.exe`) auto-detection to the MCP server's `resolveHostPath()`
- Support spawning non-DLL host paths (exe) directly in `DebuggerClient`
- Update README install instructions for npm package (`npm install -g dnd-mcp`)
- Published `dnd-mcp@0.1.0` to npm with bundled DnD.Host.dll

## Changes

### MCP server
- **`client-manager.ts`**: Add 3rd detection path in `resolveHostPath()` — checks `%USERPROFILE%\.dotnet\tools\dnd-host.exe`
- **`debugger-client.ts`**: Branch spawn logic — `.dll` paths use `spawn("dotnet", [path, ...])`, others use `spawn(path, [...])`

### Tests
- **`debugger-client.test.ts`**, **`execution.test.ts`**: Fix fallback path `net8.0-windows` → `net8.0`

### Docs
- **`README.md`**: Install via `npm install -g dnd-mcp`, MCP config with `npx -y dnd-mcp`
- **`.gitignore`**: Ignore root-level `node_modules/`, `package.json`, `package-lock.json`

## Verified

- npm package `dnd-mcp@0.1.0` published and tested
- MCP server auto-detects bundled DLL from npm package (no `DND_HOST_PATH` needed)
- MCP server auto-detects `dnd-host.exe` from dotnet global tool install
- HelloWorld fixture launches and outputs correctly via npm package
- TypeScript tests: 36/36 pass

## Commits

- `1275414` feat: auto-detect dotnet global tool and update install instructions (#23)
- `80211ea` docs: update README install instructions for npm package (#23)
- `634c86a` docs: use npx for MCP config and update .gitignore (#23)

Closes #23