### PR TITLE
feat: warn when debugging optimized (Release) modules

### DIFF
--- a/debugger/src/DnD.Core/DebuggerEngine.cs
+++ b/debugger/src/DnD.Core/DebuggerEngine.cs
@@ -1,6 +1,7 @@
 namespace DnD.Core;
 
 using System.Diagnostics;
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using ClrDebug;
 using DnD.Core.Callbacks;
@@ -875,6 +876,16 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
         session.Modules[moduleName] = (module, reader);
         _breakpointManager.OnModuleLoaded(moduleName, module, reader);
 
+        // Warn if the module has symbols but was built with optimizations enabled
+        if (reader != null && IsModuleOptimized(moduleName))
+        {
+            var fileName = Path.GetFileName(moduleName);
+            Output?.Invoke(this, new OutputEventArgs(
+                new OutputNotification(OutputCategory.Console,
+                    $"Warning: Module '{fileName}' is optimized (Release build). " +
+                    "Some local variables may be unavailable and expression evaluation may fail.")));
+        }
+
         // Handle stopAtEntry: set entry breakpoint when the target module loads
         if (session.StopAtEntry && handler.EntryBreakpoint == null && session.ProgramPath != null)
         {
@@ -887,6 +898,55 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
                 }
             }
             catch { }
+        }
+    }
+
+    /// <summary>
+    /// Checks whether an assembly was compiled with optimizations enabled by reading
+    /// the DebuggableAttribute from PE metadata.
+    /// Returns true if the module is optimized (DisableOptimizations flag is NOT set).
+    /// </summary>
+    private static bool IsModuleOptimized(string modulePath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(modulePath);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata) return false;
+
+            var metadata = peReader.GetMetadataReader();
+            var assembly = metadata.GetAssemblyDefinition();
+
+            foreach (var attrHandle in assembly.GetCustomAttributes())
+            {
+                var attr = metadata.GetCustomAttribute(attrHandle);
+                if (attr.Constructor.Kind != HandleKind.MemberReference) continue;
+
+                var memberRef = metadata.GetMemberReference((MemberReferenceHandle)attr.Constructor);
+                if (memberRef.Parent.Kind != HandleKind.TypeReference) continue;
+
+                var typeRef = metadata.GetTypeReference((TypeReferenceHandle)memberRef.Parent);
+                if (metadata.GetString(typeRef.Name) != "DebuggableAttribute" ||
+                    metadata.GetString(typeRef.Namespace) != "System.Diagnostics")
+                    continue;
+
+                // Parse custom attribute blob: prolog (2 bytes) + DebuggingModes enum (4 bytes)
+                var blob = metadata.GetBlobReader(attr.Value);
+                if (blob.Length < 6) return true;
+                blob.ReadUInt16(); // prolog 0x0001
+                var modes = blob.ReadInt32();
+
+                // DebuggingModes.DisableOptimizations = 0x100
+                return (modes & 0x100) == 0;
+            }
+
+            // No DebuggableAttribute → treat as optimized
+            return true;
+        }
+        catch
+        {
+            // Can't read metadata → don't warn
+            return false;
         }
     }
 

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,21 +1,31 @@
 {
-  "name": "dnd-mcp-server",
+  "name": "dnd-mcp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dnd-mcp-server",
+      "name": "dnd-mcp",
       "version": "0.1.0",
+      "license": "Apache-2.0",
+      "os": [
+        "win32"
+      ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
+      "bin": {
+        "dnd-mcp": "dist/index.js"
+      },
       "devDependencies": {
         "@types/node": "^25.3.3",
         "typescript": "^5.9.3",
         "vitest": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/mcp/src/tools/process.ts
+++ b/mcp/src/tools/process.ts
@@ -1,11 +1,36 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { ClientManager } from "../client-manager.js";
+import type { DebuggerClient } from "../debugger-client.js";
+import type { OutputParams } from "../types/protocol.js";
 import {
   waitForStopOrExit,
   formatStoppedResponse,
   formatExitedResponse,
 } from "./execution.js";
+
+/** Collect console-category output events (e.g. optimization warnings) from the client. */
+function collectConsoleOutput(client: DebuggerClient): {
+  getWarnings: () => string[];
+  dispose: () => void;
+} {
+  const warnings: string[] = [];
+  const onOutput = (params: OutputParams) => {
+    if (params.category === "console") {
+      warnings.push(params.output);
+    }
+  };
+  client.on("output", onOutput);
+  return {
+    getWarnings: () => warnings,
+    dispose: () => client.removeListener("output", onOutput),
+  };
+}
+
+function formatWarnings(warnings: string[]): string {
+  if (warnings.length === 0) return "";
+  return "\n" + warnings.join("\n");
+}
 
 export function registerProcessTools(
   server: McpServer,
@@ -28,11 +53,14 @@ export function registerProcessTools(
     },
     async (params) => {
       const client = await clientManager.ensureClient();
+      const collector = collectConsoleOutput(client);
       const waitPromise = waitForStopOrExit(client);
       const result = await client.launch(params);
       clientManager.markRunning();
       const event = await waitPromise;
+      collector.dispose();
 
+      const warnings = formatWarnings(collector.getWarnings());
       const hostPidLine = clientManager.hostPid
         ? `\nDebugger host PID: ${clientManager.hostPid}`
         : "";
@@ -52,7 +80,8 @@ export function registerProcessTools(
               text:
                 formatStoppedResponse(event.params, topFrame) +
                 hostPidLine +
-                outputLine,
+                outputLine +
+                warnings,
             },
           ],
         };
@@ -60,7 +89,7 @@ export function registerProcessTools(
 
       // Process ran to completion without stopping
       const exitText =
-        formatExitedResponse(event.params) + hostPidLine + outputLine;
+        formatExitedResponse(event.params) + hostPidLine + outputLine + warnings;
       await clientManager.dispose();
       return {
         content: [{ type: "text" as const, text: exitText }],
@@ -76,8 +105,15 @@ export function registerProcessTools(
     },
     async (params) => {
       const client = await clientManager.ensureClient();
+      const collector = collectConsoleOutput(client);
       const result = await client.attach(params);
       clientManager.markRunning();
+
+      // Give module-load notifications a moment to arrive
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      collector.dispose();
+
+      const warnings = formatWarnings(collector.getWarnings());
       const hostPidLine = clientManager.hostPid
         ? `\nDebugger host PID: ${clientManager.hostPid}`
         : "";
@@ -88,7 +124,7 @@ export function registerProcessTools(
         content: [
           {
             type: "text" as const,
-            text: `Attached to process ${result.processId}${hostPidLine}${outputLine}`,
+            text: `Attached to process ${result.processId}${hostPidLine}${outputLine}${warnings}`,
           },
         ],
       };


### PR DESCRIPTION
## Summary

Closes #19

Detect optimized (Release) modules at module-load time by reading `DebuggableAttribute` from PE metadata and warn users via the existing `output` notification system. The warning is included in `launch`/`attach` tool responses so LLM users know that local variables and expression evaluation may be limited.

## Changes

**C# Debugger Engine** (`debugger/src/DnD.Core/DebuggerEngine.cs`):
- Add `IsModuleOptimized(string modulePath)` — reads `DebuggableAttribute` from PE metadata via `System.Reflection.Metadata` (already a dependency) to check the `DisableOptimizations` flag
- Modify `HandleModuleLoaded()` — if a module has symbols (PDB) but is optimized, emit a warning via `Output` event with `OutputCategory.Console`

**TypeScript MCP Server** (`mcp/src/tools/process.ts`):
- Add `collectConsoleOutput()` helper to collect console-category output events during launch/attach
- Include collected warnings in `launch` and `attach` tool responses

**Filter logic**: Only modules with symbols (PDB) but without `DisableOptimizations` flag trigger a warning. Framework modules without PDBs are naturally excluded.

## Commits

- `02acf6a` feat: warn when debugging optimized (Release) modules (#19)
- `8a11f07` chore: update package-lock.json to match package.json changes from #23

## Test plan

- [x] Launch Release build → warning appears in response
- [x] Launch Debug build → no warning
- [x] Framework modules (no PDB) → no warning
- [x] `dotnet build debugger/DnD.slnx` — build succeeds
- [x] `dotnet test debugger/tests/DnD.Core.Tests` — all tests pass
- [x] `cd mcp && npm run build && npm test` — 36 tests pass