### PR TITLE
fix: keep VariablesTest process alive after Console.WriteLine for FILE_SHARE_READ verification

### DIFF
--- a/debugger/tests/fixtures/VariablesTest/Program.cs
+++ b/debugger/tests/fixtures/VariablesTest/Program.cs
@@ -14,6 +14,7 @@ class Program
         var computed = new ComputedOnly();
         Debugger.Break(); // stops here
         Console.WriteLine($"{x} {name} {pi} {flag} {computed.Value}");
+        x = 0; // keep process alive after Console.WriteLine for FILE_SHARE_READ verification
     }
 }
 


### PR DESCRIPTION
## Summary

- Add an executable statement after `Console.WriteLine` in the VariablesTest fixture so the process remains in Stopped state
- Enables E2E Scenario 2.12 to verify FILE_SHARE_READ (reading the output file while the debugger host still holds it open)

## Background

The VariablesTest fixture had no executable line after `Console.WriteLine`. A single stepOver executed it and the process exited immediately, making it impossible to read the output file while still in Stopped state. Only post-exit reading was verified.

## Changes

Added `x = 0;` after `Console.WriteLine`. After two stepOvers, the process stays in Stopped state at the new line, allowing the output file to be read while the debugger host still holds it open.

```
stepOver 1: line 15 (Debugger.Break) → line 16 (Console.WriteLine)
stepOver 2: line 16 → line 17 (x = 0) ← Console.WriteLine executed, still in Stopped state
```

## Verification

- `dotnet build debugger/DnD.slnx`: success
- `dotnet test debugger/tests/DnD.Core.Tests`: 209 passed
- `cd mcp && npm test`: 36 passed
- Manual E2E verification via MCP tools: confirmed output file (`42 hello 3.14 True 42`) is readable in Stopped state after two stepOvers

## Commits

- `91ef700` fix: add statement after Console.WriteLine in VariablesTest to keep process in stopped state

## Related

- Closes #20