### PR TITLE
fix: prevent func-eval on generic types from killing debuggee on optimized builds

### DIFF
--- a/debugger/src/DnD.Core/DebuggerEngine.cs
+++ b/debugger/src/DnD.Core/DebuggerEngine.cs
@@ -706,6 +706,8 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
             // Phase 4: Give up — force-fail the TCS so we don't hang
             session.EvalTcs.TrySetException(new TimeoutException(
                 $"Func-eval could not be aborted after {actualTimeout.TotalSeconds}s"));
+            // Recover: Evaluating → Stopped (no callback will fire)
+            lock (_lock) { _currentState = _currentState.OnEvalComplete(this); }
             throw new LocalRpcException(
                 $"Func-eval timed out and could not be aborted")
             { ErrorCode = ErrorCodes.EvaluationFailed };
@@ -837,7 +839,7 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
 
         handler.OnProcessExited += (exitCode) =>
         {
-            _currentState = _currentState.OnProcessExited(this, exitCode);
+            lock (_lock) { _currentState = _currentState.OnProcessExited(this, exitCode); }
         };
 
         handler.OnModuleLoaded += (module) =>
@@ -906,7 +908,7 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
     /// the DebuggableAttribute from PE metadata.
     /// Returns true if the module is optimized (DisableOptimizations flag is NOT set).
     /// </summary>
-    private static bool IsModuleOptimized(string modulePath)
+    internal static bool IsModuleOptimized(string modulePath)
     {
         try
         {

--- a/debugger/src/DnD.Core/DebuggerStateMachine.cs
+++ b/debugger/src/DnD.Core/DebuggerStateMachine.cs
@@ -290,6 +290,9 @@ public sealed class StoppedState : DebuggerStateBase
     public override IDebuggerState StartEval(ISessionContext ctx)
         => EvaluatingState.Instance;
 
+    public override IDebuggerState OnEvalComplete(ISessionContext ctx)
+        => this; // Late eval callback after timeout recovery — ignore
+
     public override void EnsureStopped() { } // OK — we are stopped
 }
 
@@ -345,6 +348,9 @@ public sealed class TerminatedState : DebuggerStateBase
         ctx.RaiseExitedEvent(0);
         return Task.FromResult<IDebuggerState>(this);
     }
+
+    public override IDebuggerState OnEvalComplete(ISessionContext ctx)
+        => this; // Late eval callback after process exit — ignore
 
     public override void EnsureNotTerminated()
         => throw new LocalRpcException("Process has terminated") { ErrorCode = ErrorCodes.NotAttached };

--- a/debugger/src/DnD.Core/Inspection/FuncEvalEvaluator.cs
+++ b/debugger/src/DnD.Core/Inspection/FuncEvalEvaluator.cs
@@ -33,6 +33,14 @@ public class FuncEvalEvaluator
 
     private CorDebugILFrame Frame => _frameAccessor();
 
+    /// <summary>
+    /// Returns the module path of the stopped frame for optimization detection (Issue #18).
+    /// </summary>
+    private string? StoppedModulePath
+    {
+        get { try { return Frame.Function.Module.Name; } catch { return null; } }
+    }
+
     public FuncEvalEvaluator(
         IEvalExecutor evalExecutor,
         CorDebugThread thread,
@@ -246,9 +254,10 @@ public class FuncEvalEvaluator
             var getter = MetadataHelper.FindPropertyGetter(objVal, memberName);
             if (getter != null)
             {
+                var modulePath = StoppedModulePath;
                 return await _evalExecutor.ExecuteEvalAsync(eval =>
                 {
-                    CallFunction(eval, getter, [raw]);
+                    CallFunction(eval, getter, [raw], modulePath);
                 }, _thread);
             }
         }
@@ -276,9 +285,10 @@ public class FuncEvalEvaluator
             var allArgs = new CorDebugValue[args.Length + 1];
             allArgs[0] = raw;
             Array.Copy(args, 0, allArgs, 1, args.Length);
+            var modulePath = StoppedModulePath;
             return await _evalExecutor.ExecuteEvalAsync(eval =>
             {
-                CallFunction(eval, method, allArgs);
+                CallFunction(eval, method, allArgs, modulePath);
             }, _thread);
         }
 
@@ -303,9 +313,10 @@ public class FuncEvalEvaluator
             var getItem = MetadataHelper.FindMethodByName(objVal, "get_Item", 1);
             if (getItem != null)
             {
+                var modulePath = StoppedModulePath;
                 return await _evalExecutor.ExecuteEvalAsync(eval =>
                 {
-                    CallFunction(eval, getItem, [raw, index]);
+                    CallFunction(eval, getItem, [raw, index], modulePath);
                 }, _thread);
             }
         }
@@ -317,7 +328,13 @@ public class FuncEvalEvaluator
     /// Calls a function via ICorDebugEval, using CallParameterizedFunction when
     /// the target object is a generic type (e.g., List&lt;int&gt;.Count).
     /// </summary>
-    internal static void CallFunction(CorDebugEval eval, CorDebugFunction function, CorDebugValue[] args)
+    /// <param name="stoppedModulePath">
+    /// Path of the module where the debuggee is currently stopped. Used to detect
+    /// optimized code before calling CallParameterizedFunction (Issue #18).
+    /// </param>
+    internal static void CallFunction(
+        CorDebugEval eval, CorDebugFunction function, CorDebugValue[] args,
+        string? stoppedModulePath = null)
     {
         var rawArgs = new ICorDebugValue[args.Length];
         for (int i = 0; i < args.Length; i++)
@@ -336,6 +353,16 @@ public class FuncEvalEvaluator
 
         if (typeArgs != null && typeArgs.Length > 0)
         {
+            // CallParameterizedFunction does NOT throw CORDBG_E_ILLEGAL_IN_OPTIMIZED_CODE
+            // on optimized (Release) builds, unlike CallFunction. If we proceed,
+            // process.Continue() resumes normal execution instead of eval, killing the
+            // debuggee. Pre-check the stopped frame's module and throw the same error
+            // that CallFunction would. (Issue #18)
+            if (stoppedModulePath != null && DebuggerEngine.IsModuleOptimized(stoppedModulePath))
+                throw new System.Runtime.InteropServices.COMException(
+                    "Error HRESULT CORDBG_E_ILLEGAL_IN_OPTIMIZED_CODE has been returned from a call to a COM component.",
+                    unchecked((int)0x80131C45));
+
             // Generic type — use CallParameterizedFunction
             ((ICorDebugEval2)eval.Raw).CallParameterizedFunction(
                 function.Raw, typeArgs.Length, typeArgs, rawArgs.Length, rawArgs);

--- a/debugger/tests/DnD.Core.Tests/EvalTimeoutRecoveryTests.cs
+++ b/debugger/tests/DnD.Core.Tests/EvalTimeoutRecoveryTests.cs
@@ -1,0 +1,291 @@
+namespace DnD.Core.Tests;
+
+using ClrDebug;
+using DnD.Core.Runtime;
+using DnD.Protocol;
+using StreamJsonRpc;
+
+/// <summary>
+/// Reproduces Issue #18: func-eval timeout in Phase 4 (unabortable eval) leaves the
+/// state machine stuck in Evaluating, preventing session recovery.
+///
+/// The test uses mock COM objects to deterministically reach Phase 4 (no eval callback
+/// ever fires), then verifies the state after the timeout exception.
+/// </summary>
+public class EvalTimeoutRecoveryTests : IDisposable
+{
+    private static readonly string ExistingFile =
+        typeof(EvalTimeoutRecoveryTests).Assembly.Location;
+
+    private readonly DebuggerEngine _engine;
+    private readonly EvalTimeoutLauncher _launcher;
+
+    public EvalTimeoutRecoveryTests()
+    {
+        _launcher = new EvalTimeoutLauncher();
+        _engine = new DebuggerEngine(_launcher);
+    }
+
+    public void Dispose() => _engine.Dispose();
+
+    /// <summary>
+    /// After Phase 4 timeout, state recovers to Stopped and a subsequent eval attempt
+    /// passes the state check (StartEval succeeds). The second eval also times out
+    /// (no callback fires), proving the session remains usable.
+    /// </summary>
+    [Fact]
+    public async Task Phase4Timeout_StateRecoversToStopped_SubsequentEvalWorks()
+    {
+        // Arrange: Launch and transition to Stopped state
+        await _engine.LaunchAsync(new LaunchRequest(Program: ExistingFile));
+        _launcher.SimulateBreak();
+
+        // Act: Execute eval that will time out through all phases (no callback fires)
+        var thread = new CorDebugThread(_launcher.MockThread);
+        var ex = await Assert.ThrowsAsync<LocalRpcException>(
+            () => _engine.ExecuteEvalAsync(_ => { }, thread, TimeSpan.FromMilliseconds(10)));
+
+        // Assert: Phase 4 error message
+        Assert.Contains("could not be aborted", ex.Message);
+
+        // FIX: State recovered to Stopped — a second eval passes StartEval and
+        // enters the timeout cycle again (proving the session is still alive).
+        var secondThread = new CorDebugThread(_launcher.MockThread);
+        var secondEx = await Assert.ThrowsAsync<LocalRpcException>(
+            () => _engine.ExecuteEvalAsync(_ => { }, secondThread, TimeSpan.FromMilliseconds(10)));
+        Assert.Contains("could not be aborted", secondEx.Message);
+    }
+
+    /// <summary>
+    /// If the process dies after Phase 4 recovery (due to Phase 3's process.Stop()
+    /// destabilization), OnProcessExited transitions Stopped → Terminated.
+    /// With the _lock fix, this transition is properly serialized.
+    /// </summary>
+    [Fact]
+    public async Task Phase4Timeout_ProcessDies_TransitionsToTerminated()
+    {
+        // Arrange: Launch and transition to Stopped state
+        ExitedNotification? exitedNotification = null;
+        _engine.Exited += (_, e) => exitedNotification = e.Notification;
+
+        await _engine.LaunchAsync(new LaunchRequest(Program: ExistingFile));
+        _launcher.SimulateBreak();
+
+        // Act: Execute eval that will time out
+        var thread = new CorDebugThread(_launcher.MockThread);
+        var ex = await Assert.ThrowsAsync<LocalRpcException>(
+            () => _engine.ExecuteEvalAsync(_ => { }, thread, TimeSpan.FromMilliseconds(10)));
+        Assert.Contains("could not be aborted", ex.Message);
+
+        // Simulate process death — now runs with _lock, properly serialized.
+        // State transitions: Stopped (recovered) → Terminated via OnProcessExited.
+        _launcher.SimulateProcessExit(exitCode: -1);
+
+        // Verify: Exited event was fired
+        Assert.NotNull(exitedNotification);
+
+        // Session is destroyed (expected for process death) — subsequent eval fails.
+        var secondThread = new CorDebugThread(_launcher.MockThread);
+        var sessionEx = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _engine.ExecuteEvalAsync(_ => { }, secondThread, TimeSpan.FromMilliseconds(10)));
+        Assert.Contains("No active debug session", sessionEx.Message);
+    }
+
+    /// <summary>
+    /// A late eval callback arriving after Phase 4 recovery (state = Stopped) is
+    /// gracefully ignored by StoppedState.OnEvalComplete.
+    /// </summary>
+    [Fact]
+    public async Task LateEvalCallback_AfterPhase4Recovery_IsIgnored()
+    {
+        // Arrange: Launch and transition to Stopped state
+        await _engine.LaunchAsync(new LaunchRequest(Program: ExistingFile));
+        _launcher.SimulateBreak();
+
+        // Act: Execute eval that times out (Phase 4) — state recovers to Stopped
+        var thread = new CorDebugThread(_launcher.MockThread);
+        await Assert.ThrowsAsync<LocalRpcException>(
+            () => _engine.ExecuteEvalAsync(_ => { }, thread, TimeSpan.FromMilliseconds(10)));
+
+        // Simulate late eval callback arriving after Phase 4 recovery.
+        // StoppedState.OnEvalComplete handles this as a no-op (returns this).
+        var lateCallbackEx = Record.Exception(() => _launcher.SimulateEvalComplete());
+        Assert.Null(lateCallbackEx);
+    }
+
+    /// <summary>
+    /// A late eval callback arriving after Phase 4 + process death (state = Terminated)
+    /// is gracefully ignored by TerminatedState.OnEvalComplete.
+    /// This is the exact sequence observed in E2E testing with Release builds.
+    /// </summary>
+    [Fact]
+    public async Task LateEvalCallback_AfterProcessDeath_IsIgnored()
+    {
+        // Arrange: Launch and transition to Stopped state
+        await _engine.LaunchAsync(new LaunchRequest(Program: ExistingFile));
+        _launcher.SimulateBreak();
+
+        // Phase 4 timeout — state recovers to Stopped
+        var thread = new CorDebugThread(_launcher.MockThread);
+        await Assert.ThrowsAsync<LocalRpcException>(
+            () => _engine.ExecuteEvalAsync(_ => { }, thread, TimeSpan.FromMilliseconds(10)));
+
+        // Process dies — state transitions Stopped → Terminated
+        _launcher.SimulateProcessExit(exitCode: -1);
+
+        // Late eval callback arrives in Terminated state — must not throw
+        var lateCallbackEx = Record.Exception(() => _launcher.SimulateEvalComplete());
+        Assert.Null(lateCallbackEx);
+    }
+
+    // ── Mock IProcessLauncher ───────────────────────────────────────────
+
+    private class EvalTimeoutLauncher : IProcessLauncher
+    {
+        private CorDebugManagedCallback? _savedCallback;
+        public MockCorDebugThread MockThread { get; } = new();
+
+        public LaunchResult Launch(
+            string program, string[]? args, string? cwd,
+            Dictionary<string, string>? env,
+            CorDebugManagedCallback callback)
+        {
+            _savedCallback = callback;
+            return new LaunchResult(
+                new CorDebug(new MockCorDebug()),
+                new CorDebugProcess(new MockCorDebugProcess()));
+        }
+
+        public LaunchResult Attach(int processId, CorDebugManagedCallback callback)
+            => throw new NotImplementedException();
+
+        /// <summary>Fire a Break callback to transition Running → Stopped.</summary>
+        public void SimulateBreak()
+        {
+            var mcb = (ICorDebugManagedCallback)_savedCallback!;
+            mcb.Break(new MockCorDebugAppDomain(), MockThread);
+        }
+
+        /// <summary>Fire an ExitProcess callback to simulate process death.</summary>
+        public void SimulateProcessExit(int exitCode)
+        {
+            var mcb = (ICorDebugManagedCallback)_savedCallback!;
+            mcb.ExitProcess(new MockCorDebugProcess());
+        }
+
+        /// <summary>Fire an EvalComplete callback to simulate late eval result.</summary>
+        public void SimulateEvalComplete()
+        {
+            var mcb = (ICorDebugManagedCallback)_savedCallback!;
+            mcb.EvalComplete(new MockCorDebugAppDomain(), new MockCorDebugThread(), new MockCorDebugEval());
+        }
+    }
+
+    // ── Mock COM implementations ────────────────────────────────────────
+
+    internal class MockCorDebugThread : ICorDebugThread
+    {
+        public HRESULT GetProcess(out ICorDebugProcess ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetID(out int pdwThreadId) { pdwThreadId = 1; return HRESULT.S_OK; }
+        public HRESULT GetHandle(out IntPtr phThreadHandle) { phThreadHandle = IntPtr.Zero; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetAppDomain(out ICorDebugAppDomain ppAppDomain) { ppAppDomain = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT SetDebugState(CorDebugThreadState state) => HRESULT.E_NOTIMPL;
+        public HRESULT GetDebugState(out CorDebugThreadState pState) { pState = default; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetUserState(out CorDebugUserState pState) { pState = default; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetCurrentException(out ICorDebugValue ppExceptionObject) { ppExceptionObject = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT ClearCurrentException() => HRESULT.E_NOTIMPL;
+        public HRESULT CreateStepper(out ICorDebugStepper ppStepper) { ppStepper = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateChains(out ICorDebugChainEnum ppChains) { ppChains = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetActiveChain(out ICorDebugChain ppChain) { ppChain = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetActiveFrame(out ICorDebugFrame ppFrame) { ppFrame = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetRegisterSet(out ICorDebugRegisterSet ppRegisters) { ppRegisters = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT CreateEval(out ICorDebugEval ppEval)
+        {
+            ppEval = new MockCorDebugEval();
+            return HRESULT.S_OK;
+        }
+        public HRESULT GetObject(out ICorDebugValue ppObject) { ppObject = null!; return HRESULT.E_NOTIMPL; }
+    }
+
+    internal class MockCorDebugEval : ICorDebugEval
+    {
+        public HRESULT CallFunction(ICorDebugFunction pFunction, int nArgs, ICorDebugValue[] ppArgs) => HRESULT.E_NOTIMPL;
+        public HRESULT NewObject(ICorDebugFunction pConstructor, int nArgs, ICorDebugValue[] ppArgs) => HRESULT.E_NOTIMPL;
+        public HRESULT NewObjectNoConstructor(ICorDebugClass pClass) => HRESULT.E_NOTIMPL;
+        public HRESULT NewString(string @string) => HRESULT.E_NOTIMPL;
+        public HRESULT NewArray(CorElementType elementType, ICorDebugClass pElementClass, int rank, int[] dims, int[] lowBounds) => HRESULT.E_NOTIMPL;
+        public HRESULT IsActive(out bool pbActive) { pbActive = false; return HRESULT.S_OK; }
+        public HRESULT Abort() => HRESULT.S_OK;
+        public HRESULT GetResult(out ICorDebugValue ppResult) { ppResult = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetThread(out ICorDebugThread ppThread) { ppThread = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT CreateValue(CorElementType elementType, ICorDebugClass pElementClass, out ICorDebugValue ppValue) { ppValue = null!; return HRESULT.E_NOTIMPL; }
+    }
+
+    private class MockCorDebugAppDomain : ICorDebugAppDomain
+    {
+        public HRESULT GetProcess(out ICorDebugProcess ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateAssemblies(out ICorDebugAssemblyEnum ppAssemblies) { ppAssemblies = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetModuleFromMetaDataInterface(object pIMetaData, out ICorDebugModule ppModule) { ppModule = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateBreakpoints(out ICorDebugBreakpointEnum ppBreakpoints) { ppBreakpoints = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateSteppers(out ICorDebugStepperEnum ppSteppers) { ppSteppers = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT IsAttached(out bool pbAttached) { pbAttached = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetName(int cchName, out int pcchName, char[]? szName) { pcchName = 0; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetObject(out ICorDebugValue ppObject) { ppObject = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT Attach() => HRESULT.S_OK;
+        public HRESULT GetID(out int pId) { pId = 1; return HRESULT.S_OK; }
+        public HRESULT Stop(int dwTimeoutIgnored) => HRESULT.S_OK;
+        public HRESULT Continue(bool fIsOutOfBand) => HRESULT.S_OK;
+        public HRESULT IsRunning(out bool pbRunning) { pbRunning = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT HasQueuedCallbacks(ICorDebugThread? pThread, out bool pbQueued) { pbQueued = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateThreads(out ICorDebugThreadEnum ppThreads) { ppThreads = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT SetAllThreadsDebugState(CorDebugThreadState state, ICorDebugThread? pExceptThisThread) => HRESULT.E_NOTIMPL;
+        public HRESULT Detach() => HRESULT.S_OK;
+        public HRESULT Terminate(int exitCode) => HRESULT.S_OK;
+        public HRESULT CanCommitChanges(int cSnapshots, ref ICorDebugEditAndContinueSnapshot pSnapshots, out ICorDebugErrorInfoEnum pError) { pError = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT CommitChanges(int cSnapshots, ref ICorDebugEditAndContinueSnapshot pSnapshots, out ICorDebugErrorInfoEnum pError) { pError = null!; return HRESULT.E_NOTIMPL; }
+    }
+
+    private class MockCorDebug : ICorDebug
+    {
+        public HRESULT Initialize() => HRESULT.S_OK;
+        public HRESULT Terminate() => HRESULT.S_OK;
+        public HRESULT SetManagedHandler(ICorDebugManagedCallback pCallback) => HRESULT.S_OK;
+        public HRESULT SetUnmanagedHandler(ICorDebugUnmanagedCallback pCallback) => HRESULT.E_NOTIMPL;
+        public HRESULT CreateProcess(string lpApplicationName, string lpCommandLine, ref SECURITY_ATTRIBUTES lpProcessAttributes, ref SECURITY_ATTRIBUTES lpThreadAttributes, bool bInheritHandles, CreateProcessFlags dwCreationFlags, IntPtr lpEnvironment, string lpCurrentDirectory, ref STARTUPINFOW lpStartupInfo, ref PROCESS_INFORMATION lpProcessInformation, CorDebugCreateProcessFlags debuggingFlags, out ICorDebugProcess ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT DebugActiveProcess(int id, bool win32Attach, out ICorDebugProcess ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateProcesses(out ICorDebugProcessEnum ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetProcess(int dwProcessId, out ICorDebugProcess ppProcess) { ppProcess = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT CanLaunchOrAttach(int dwProcessId, int win32DebuggingEnabled) => HRESULT.E_NOTIMPL;
+    }
+
+    private class MockCorDebugProcess : ICorDebugProcess
+    {
+        public HRESULT GetID(out int pdwProcessId) { pdwProcessId = 9999; return HRESULT.S_OK; }
+        public HRESULT GetHandle(out IntPtr phProcessHandle) { phProcessHandle = IntPtr.Zero; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetThread(int dwThreadId, out ICorDebugThread ppThread) { ppThread = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateObjects(out ICorDebugObjectEnum ppObjects) { ppObjects = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT IsTransitionStub(CORDB_ADDRESS address, out bool pbTransitionStub) { pbTransitionStub = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT IsOSSuspended(int threadID, out bool pbSuspended) { pbSuspended = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetThreadContext(int threadID, int contextSize, IntPtr context) => HRESULT.E_NOTIMPL;
+        public HRESULT SetThreadContext(int threadID, int contextSize, IntPtr context) => HRESULT.E_NOTIMPL;
+        public HRESULT ReadMemory(CORDB_ADDRESS address, int size, IntPtr buffer, out int read) { read = 0; return HRESULT.E_NOTIMPL; }
+        public HRESULT WriteMemory(CORDB_ADDRESS address, int size, IntPtr buffer, out int written) { written = 0; return HRESULT.E_NOTIMPL; }
+        public HRESULT ClearCurrentException(int threadID) => HRESULT.E_NOTIMPL;
+        public HRESULT EnableLogMessages(bool fOnOff) => HRESULT.E_NOTIMPL;
+        public HRESULT ModifyLogSwitch(string pLogSwitchName, int lLevel) => HRESULT.E_NOTIMPL;
+        public HRESULT EnumerateAppDomains(out ICorDebugAppDomainEnum ppAppDomains) { ppAppDomains = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetObject(out ICorDebugValue ppObject) { ppObject = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT ThreadForFiberCookie(int fiberCookie, out ICorDebugThread ppThread) { ppThread = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT GetHelperThreadID(out int pThreadID) { pThreadID = 0; return HRESULT.E_NOTIMPL; }
+        public HRESULT Stop(int dwTimeoutIgnored) => HRESULT.S_OK;
+        public HRESULT Continue(bool fIsOutOfBand) => HRESULT.S_OK;
+        public HRESULT IsRunning(out bool pbRunning) { pbRunning = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT HasQueuedCallbacks(ICorDebugThread? pThread, out bool pbQueued) { pbQueued = false; return HRESULT.E_NOTIMPL; }
+        public HRESULT EnumerateThreads(out ICorDebugThreadEnum ppThreads) { ppThreads = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT SetAllThreadsDebugState(CorDebugThreadState state, ICorDebugThread? pExceptThisThread) => HRESULT.E_NOTIMPL;
+        public HRESULT Detach() => HRESULT.S_OK;
+        public HRESULT Terminate(int exitCode) => HRESULT.S_OK;
+        public HRESULT CanCommitChanges(int cSnapshots, ref ICorDebugEditAndContinueSnapshot pSnapshots, out ICorDebugErrorInfoEnum pError) { pError = null!; return HRESULT.E_NOTIMPL; }
+        public HRESULT CommitChanges(int cSnapshots, ref ICorDebugEditAndContinueSnapshot pSnapshots, out ICorDebugErrorInfoEnum pError) { pError = null!; return HRESULT.E_NOTIMPL; }
+    }
+}

--- a/debugger/tests/DnD.Host.Tests/ReleaseEvalTests.cs
+++ b/debugger/tests/DnD.Host.Tests/ReleaseEvalTests.cs
@@ -1,0 +1,131 @@
+namespace DnD.Host.Tests;
+
+using DnD.Protocol;
+using StreamJsonRpc;
+
+/// <summary>
+/// Tests that func-eval on Release (optimized) builds returns errors
+/// without killing the debuggee process.
+/// Reproduces: https://github.com/hnmr293/DnD/issues/18
+///
+/// Root cause: ICorDebugEval2.CallParameterizedFunction (used for generic types)
+/// does NOT throw CORDBG_E_ILLEGAL_IN_OPTIMIZED_CODE on optimized code, unlike
+/// ICorDebugEval.CallFunction. When process.Continue(false) is called, the CLR
+/// cannot hijack the thread for eval, so the process resumes normal execution
+/// and exits.
+/// </summary>
+[Collection("DebugSession")]
+[Trait("Category", "ReleaseEval")]
+public class ReleaseEvalGenericTypeTests : DebugTestBase
+{
+    private int _stoppedThreadId;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        var program = FindReleaseFixture("EvalTest");
+        await Rpc!.InvokeWithParameterObjectAsync<LaunchResponse>(
+            "launch", new LaunchRequest(Program: program));
+
+        var stopped = WaitForStopped();
+        Assert.Equal(StopReason.Pause, stopped.Reason);
+        _stoppedThreadId = stopped.ThreadId;
+
+        await Rpc!.InvokeWithParameterObjectAsync<GetStackTraceResponse>(
+            "getStackTrace", new GetStackTraceRequest(ThreadId: stopped.ThreadId));
+    }
+
+    /// <summary>
+    /// Reproduces Issue #18: evaluating a property on a generic type
+    /// (List&lt;int&gt;.Count) on a Release build kills the debuggee process.
+    ///
+    /// CallParameterizedFunction does not throw on optimized code.
+    /// process.Continue resumes normal execution → process exits with code 0.
+    /// </summary>
+    [Fact]
+    public async Task Evaluate_GenericPropertyOnOptimizedCode_ReturnsErrorWithoutKillingProcess()
+    {
+        // Act: evaluate list.Count — triggers CallParameterizedFunction
+        var ex = await Assert.ThrowsAsync<RemoteInvocationException>(
+            () => Rpc!.InvokeWithParameterObjectAsync<EvaluateResponse>(
+                "evaluate", new EvaluateRequest(Expression: "list.Count")));
+
+        // Assert: process must NOT have exited
+        Assert.False(ExitedTcs.Task.IsCompleted,
+            "Process exited — eval on optimized generic type killed the debuggee (Issue #18)");
+
+        // Assert: session is still functional
+        var stack = await Rpc!.InvokeWithParameterObjectAsync<GetStackTraceResponse>(
+            "getStackTrace", new GetStackTraceRequest(ThreadId: _stoppedThreadId));
+        Assert.NotEmpty(stack.StackFrames);
+    }
+
+    private string FindReleaseFixture(string name)
+    {
+        var tfm = TargetFramework;
+        var ext = tfm.StartsWith("net4") ? ".exe" : ".dll";
+        var fixturePath = FindPath($"tests/fixtures/{name}/bin/Release/{tfm}/{name}{ext}");
+        if (!File.Exists(fixturePath))
+            throw new FileNotFoundException(
+                $"Release fixture not built. Run: dotnet build tests/fixtures/{name} -c Release\nExpected: {fixturePath}");
+        return fixturePath;
+    }
+}
+
+/// <summary>
+/// Control test: non-generic type eval on Release builds correctly throws
+/// CORDBG_E_ILLEGAL_IN_OPTIMIZED_CODE and the session stays alive.
+/// </summary>
+[Collection("DebugSession")]
+[Trait("Category", "ReleaseEval")]
+public class ReleaseEvalNonGenericTypeTests : DebugTestBase
+{
+    private int _stoppedThreadId;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        var program = FindReleaseFixture("EvalTest");
+        await Rpc!.InvokeWithParameterObjectAsync<LaunchResponse>(
+            "launch", new LaunchRequest(Program: program));
+
+        var stopped = WaitForStopped();
+        Assert.Equal(StopReason.Pause, stopped.Reason);
+        _stoppedThreadId = stopped.ThreadId;
+
+        await Rpc!.InvokeWithParameterObjectAsync<GetStackTraceResponse>(
+            "getStackTrace", new GetStackTraceRequest(ThreadId: stopped.ThreadId));
+    }
+
+    [Fact]
+    public async Task Evaluate_NonGenericPropertyOnOptimizedCode_ReturnsErrorWithoutKillingProcess()
+    {
+        // Act: evaluate obj.Name — triggers CallFunction (non-generic)
+        // This correctly throws CORDBG_E_ILLEGAL_IN_OPTIMIZED_CODE before Continue
+        var ex = await Assert.ThrowsAsync<RemoteInvocationException>(
+            () => Rpc!.InvokeWithParameterObjectAsync<EvaluateResponse>(
+                "evaluate", new EvaluateRequest(Expression: "obj.Name")));
+
+        // Assert: process must NOT have exited
+        Assert.False(ExitedTcs.Task.IsCompleted,
+            "Process exited — eval on optimized non-generic type killed the debuggee");
+
+        // Assert: session is still functional
+        var stack = await Rpc!.InvokeWithParameterObjectAsync<GetStackTraceResponse>(
+            "getStackTrace", new GetStackTraceRequest(ThreadId: _stoppedThreadId));
+        Assert.NotEmpty(stack.StackFrames);
+    }
+
+    private string FindReleaseFixture(string name)
+    {
+        var tfm = TargetFramework;
+        var ext = tfm.StartsWith("net4") ? ".exe" : ".dll";
+        var fixturePath = FindPath($"tests/fixtures/{name}/bin/Release/{tfm}/{name}{ext}");
+        if (!File.Exists(fixturePath))
+            throw new FileNotFoundException(
+                $"Release fixture not built. Run: dotnet build tests/fixtures/{name} -c Release\nExpected: {fixturePath}");
+        return fixturePath;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #18

- **Root cause**: `ICorDebugEval2.CallParameterizedFunction` (used for generic types like `List<int>.Count`) does not throw `CORDBG_E_ILLEGAL_IN_OPTIMIZED_CODE` on Release builds, unlike `ICorDebugEval.CallFunction`. When `process.Continue()` is called, the CLR cannot hijack the thread for eval, so the process resumes normal execution and exits.
- **Fix**: Before calling `CallParameterizedFunction`, check if the stopped frame's module is optimized (reusing `IsModuleOptimized` from #25) and throw the same COM error early — before `process.Continue()` is called, keeping the session alive.
- **Defense in depth**: Add Phase 4 timeout state recovery (`Evaluating → Stopped`) and lock `OnProcessExited` to handle truly unabortable evals (e.g., infinite loops).

## Changes

| File | Change |
|------|--------|
| `FuncEvalEvaluator.cs` | Pre-check stopped frame's module optimization before `CallParameterizedFunction`; pass `stoppedModulePath` from all 3 call sites |
| `DebuggerEngine.cs` | Phase 4 state recovery; lock `OnProcessExited`; `IsModuleOptimized` visibility `private` → `internal` |
| `DebuggerStateMachine.cs` | `StoppedState.OnEvalComplete` and `TerminatedState.OnEvalComplete` to handle late callbacks |
| `ReleaseEvalTests.cs` (new) | Integration tests: generic + non-generic eval on Release builds — verifies session survives |
| `EvalTimeoutRecoveryTests.cs` (new) | Unit tests: Phase 4 recovery, late callback handling |

## Test plan

- [x] `dotnet test debugger/tests/DnD.Core.Tests` — 213 tests pass
- [x] `dotnet test debugger/tests/DnD.Host.Tests --filter ReleaseEval` — 2 tests pass (bug reproduction)
- [x] `dotnet test debugger/tests/DnD.Host.Tests --filter EvalTests` — 60 tests pass (Debug + net48, no regression)
- [x] Full E2E test plan (19 scenarios) — all pass