### PR TITLE
chore: add GitHub links to package.json and bump to 0.2.1

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dnd-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dnd-mcp",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "os": [
         "win32"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnd-mcp",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP server for DnD .NET debugger — debug C# programs via MCP",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -24,6 +24,15 @@
     "csharp",
     "model-context-protocol"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hnmr293/DnD.git",
+    "directory": "mcp"
+  },
+  "homepage": "https://github.com/hnmr293/DnD#readme",
+  "bugs": {
+    "url": "https://github.com/hnmr293/DnD/issues"
+  },
   "license": "Apache-2.0",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary
- Add `repository`, `homepage`, and `bugs` fields to `mcp/package.json` for npm listing
- Bump version from 0.2.0 to 0.2.1

## Notes
- npm 0.2.0 is already published; this version bump is required for the publish workflow to succeed
- The publish workflow (added in #29) will automatically publish 0.2.1 on merge