### PR TITLE
Release v0.4.0: async state machine debugging

### DIFF
--- a/debugger/src/DnD.Core/DebuggerEngine.cs
+++ b/debugger/src/DnD.Core/DebuggerEngine.cs
@@ -1229,6 +1229,25 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
     private static List<Variable> GetFrameVariables(CorDebugILFrame frame, ValueReader valueReader, DebugSession session)
     {
         var variables = new List<Variable>();
+
+        // Check if we're inside an async/iterator state machine's MoveNext
+        var stateMachineObj = TryGetStateMachineObject(frame);
+        if (stateMachineObj != null)
+        {
+            var unwrapped = Inspection.StateMachineHelper.UnwrapFields(stateMachineObj);
+            foreach (var (name, value) in unwrapped)
+            {
+                try
+                {
+                    var (displayValue, type) = valueReader.Read(value);
+                    variables.Add(new Variable(name, displayValue, type));
+                }
+                catch { }
+            }
+            return variables;
+        }
+
+        // Normal (non-state-machine) frame: collect locals and arguments
         var module = frame.Function.Module;
         var reader = GetSymbolReader(module, session);
 
@@ -1279,6 +1298,33 @@ public class DebuggerEngine : IDebuggerEngine, ISessionContext, IEvalExecutor, I
         catch { }
 
         return variables;
+    }
+
+    /// <summary>
+    /// If the frame is inside a state machine's MoveNext, returns the state machine
+    /// object (argument 0, dereferenced). Otherwise returns null.
+    /// </summary>
+    private static CorDebugObjectValue? TryGetStateMachineObject(CorDebugILFrame frame)
+    {
+        try
+        {
+            var thisVal = frame.GetArgument(0);
+            var typeName = Inspection.TypeNameResolver.GetCSharpTypeName(thisVal);
+            if (!Inspection.StateMachineHelper.IsStateMachineType(typeName))
+                return null;
+
+            // Dereference to get the object value
+            if (thisVal is CorDebugReferenceValue refVal)
+            {
+                if (refVal.IsNull) return null;
+                thisVal = refVal.Dereference();
+            }
+            if (thisVal is CorDebugBoxValue boxVal)
+                thisVal = boxVal.Object;
+
+            return thisVal as CorDebugObjectValue;
+        }
+        catch { return null; }
     }
 
     private static Dictionary<int, string> GetArgumentNameMap(MetaDataImport import, mdMethodDef methodToken)

--- a/debugger/src/DnD.Core/Inspection/RoslynEvaluator.cs
+++ b/debugger/src/DnD.Core/Inspection/RoslynEvaluator.cs
@@ -110,60 +110,97 @@ public class RoslynEvaluator
                 try
                 {
                     var thisValue = frame.GetArgument(0);
-                    ctx.ThisValue = thisValue;
-                    ctx.ThisTypeName = TypeNameResolver.GetCSharpTypeName(thisValue);
+                    var thisTypeName = TypeNameResolver.GetCSharpTypeName(thisValue);
+
+                    // State machine: unwrap <>4__this as the real "this" and
+                    // extract hoisted fields as locals
+                    if (StateMachineHelper.IsStateMachineType(thisTypeName))
+                    {
+                        var smObj = DereferenceToObject(thisValue);
+                        if (smObj != null)
+                        {
+                            // Get outer "this" if the async method is an instance method
+                            var outerThis = StateMachineHelper.GetOuterThis(smObj);
+                            if (outerThis != null)
+                            {
+                                ctx.ThisValue = outerThis;
+                                ctx.ThisTypeName = TypeNameResolver.GetCSharpTypeName(outerThis);
+                            }
+                            // else: static async method — no outer this
+
+                            // Add state machine fields as locals
+                            var unwrapped = StateMachineHelper.UnwrapFields(smObj);
+                            foreach (var (name, value) in unwrapped)
+                            {
+                                if (name == "this") continue; // already handled above
+                                try
+                                {
+                                    var typeName = TypeNameResolver.GetCSharpTypeName(value);
+                                    ctx.Locals.Add(new EvalLocal(name, typeName, value));
+                                }
+                                catch { }
+                            }
+                            ctx.IsStateMachine = true;
+                        }
+                    }
+                    else
+                    {
+                        ctx.ThisValue = thisValue;
+                        ctx.ThisTypeName = thisTypeName;
+                    }
                 }
                 catch { }
             }
         }
         catch { }
 
-        // Collect local variables
-        if (reader != null)
+        // Collect local variables and parameters (skip if state machine — already handled)
+        if (!ctx.IsStateMachine)
         {
+            if (reader != null)
+            {
+                try
+                {
+                    var ipResult = frame.IP;
+                    var ilOffset = (int)ipResult.pnOffset;
+                    var locals = reader.GetLocalVariables((int)frame.Function.Token, ilOffset);
+                    foreach (var local in locals)
+                    {
+                        try
+                        {
+                            var value = frame.GetLocalVariable(local.SlotIndex);
+                            var typeName = TypeNameResolver.GetCSharpTypeName(value);
+                            ctx.Locals.Add(new EvalLocal(local.Name, typeName, value));
+                        }
+                        catch { }
+                    }
+                }
+                catch { }
+            }
+
             try
             {
-                var ipResult = frame.IP;
-                var ilOffset = (int)ipResult.pnOffset;
-                var locals = reader.GetLocalVariables((int)frame.Function.Token, ilOffset);
-                foreach (var local in locals)
+                var module = frame.Function.Module;
+                var import = module.GetMetaDataInterface<MetaDataImport>();
+                var methodToken = (mdMethodDef)frame.Function.Token;
+                var argNameMap = GetArgumentNameMap(import, methodToken, ctx.IsStatic);
+
+                int startIdx = ctx.IsStatic ? 0 : 1;
+                for (int i = startIdx; ; i++)
                 {
                     try
                     {
-                        var value = frame.GetLocalVariable(local.SlotIndex);
+                        var value = frame.GetArgument(i);
+                        var name = argNameMap.GetValueOrDefault(i, $"arg{i}");
+                        if (name == "this") continue;
                         var typeName = TypeNameResolver.GetCSharpTypeName(value);
-                        ctx.Locals.Add(new EvalLocal(local.Name, typeName, value));
+                        ctx.Locals.Add(new EvalLocal(name, typeName, value));
                     }
-                    catch { }
+                    catch { break; }
                 }
             }
             catch { }
         }
-
-        // Collect parameters
-        try
-        {
-            var module = frame.Function.Module;
-            var import = module.GetMetaDataInterface<MetaDataImport>();
-            var methodToken = (mdMethodDef)frame.Function.Token;
-            var argNameMap = GetArgumentNameMap(import, methodToken, ctx.IsStatic);
-
-            // Start from index 1 for instance methods (0 is 'this')
-            int startIdx = ctx.IsStatic ? 0 : 1;
-            for (int i = startIdx; ; i++)
-            {
-                try
-                {
-                    var value = frame.GetArgument(i);
-                    var name = argNameMap.GetValueOrDefault(i, $"arg{i}");
-                    if (name == "this") continue;
-                    var typeName = TypeNameResolver.GetCSharpTypeName(value);
-                    ctx.Locals.Add(new EvalLocal(name, typeName, value));
-                }
-                catch { break; }
-            }
-        }
-        catch { }
 
         // Pseudo-variables
         if (exceptionValue != null)
@@ -307,6 +344,11 @@ public class RoslynEvaluator
     /// </summary>
     private static bool NeedsObjectParameter(string typeName)
     {
+        // Compiler-generated type names (e.g., <Method>d__3) contain '<'
+        // which is invalid in C# source. Must use object.
+        if (typeName.Contains('<'))
+            return true;
+
         // Primitives — always public
         if (typeName is "int" or "uint" or "long" or "ulong" or
             "short" or "ushort" or "byte" or "sbyte" or
@@ -760,11 +802,24 @@ public class RoslynEvaluator
     {
         public string? SourceFilePath { get; set; }
         public bool IsStatic { get; set; }
+        public bool IsStateMachine { get; set; }
         public string? ThisTypeName { get; set; }
         public CorDebugValue? ThisValue { get; set; }
         public List<EvalLocal> Locals { get; } = new();
         public bool HasException { get; set; }
         public bool HasReturnValue { get; set; }
+    }
+
+    private static CorDebugObjectValue? DereferenceToObject(CorDebugValue value)
+    {
+        if (value is CorDebugReferenceValue refVal)
+        {
+            if (refVal.IsNull) return null;
+            value = refVal.Dereference();
+        }
+        if (value is CorDebugBoxValue boxVal)
+            value = boxVal.Object;
+        return value as CorDebugObjectValue;
     }
 
     private record EvalLocal(string Name, string TypeName, CorDebugValue Value);

--- a/debugger/src/DnD.Core/Inspection/SimpleEvaluator.cs
+++ b/debugger/src/DnD.Core/Inspection/SimpleEvaluator.cs
@@ -164,6 +164,23 @@ public class SimpleEvaluator
             catch { return null; }
         }
 
+        // Fallback: check if we're in a state machine and look up the field
+        try
+        {
+            var thisVal = frame.GetArgument(0);
+            var typeName = TypeNameResolver.GetCSharpTypeName(thisVal);
+            if (StateMachineHelper.IsStateMachineType(typeName))
+            {
+                if (thisVal is CorDebugReferenceValue refVal2 && !refVal2.IsNull)
+                    thisVal = refVal2.Dereference();
+                if (thisVal is CorDebugBoxValue boxVal2)
+                    thisVal = boxVal2.Object;
+                if (thisVal is CorDebugObjectValue objVal)
+                    return StateMachineHelper.FindVariable(objVal, name);
+            }
+        }
+        catch { }
+
         return null;
     }
 

--- a/debugger/src/DnD.Core/Inspection/StateMachineHelper.cs
+++ b/debugger/src/DnD.Core/Inspection/StateMachineHelper.cs
@@ -1,0 +1,191 @@
+namespace DnD.Core.Inspection;
+
+using System.Text.RegularExpressions;
+using ClrDebug;
+
+/// <summary>
+/// Detects async/iterator state machines and unwraps their fields
+/// into user-visible variable names following Roslyn's naming conventions.
+/// </summary>
+public static class StateMachineHelper
+{
+    // Matches compiler-generated state machine type names: <MethodName>d__N
+    // May be preceded by namespace/class path (e.g., Namespace.Class/<Method>d__3)
+    private static readonly Regex StateMachineTypePattern =
+        new(@"<\w+>d__\d+$", RegexOptions.Compiled);
+
+    // Matches hoisted local variable fields: <variableName>5__N
+    private static readonly Regex HoistedLocalPattern =
+        new(@"^<(.+)>5__\d+$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns true if the type name matches Roslyn's state machine naming pattern.
+    /// </summary>
+    public static bool IsStateMachineType(string typeName)
+    {
+        if (string.IsNullOrEmpty(typeName))
+            return false;
+        return StateMachineTypePattern.IsMatch(typeName);
+    }
+
+    /// <summary>
+    /// Attempts to map a state machine field name to the original variable name.
+    /// Returns false for internal fields that should be hidden from the user.
+    /// </summary>
+    public static bool TryGetVariableName(string fieldName, out string variableName)
+    {
+        variableName = "";
+
+        if (string.IsNullOrEmpty(fieldName))
+            return false;
+
+        // <>4__this → the captured outer "this"
+        if (fieldName == "<>4__this")
+        {
+            variableName = "this";
+            return true;
+        }
+
+        // Fields starting with <> (empty name between angle brackets) are internal
+        // Examples: <>1__state, <>t__builder, <>u__1, <>s__1, <>7__wrap1
+        if (fieldName.StartsWith("<>"))
+            return false;
+
+        // <variableName>5__N → hoisted local variable
+        var match = HoistedLocalPattern.Match(fieldName);
+        if (match.Success)
+        {
+            variableName = match.Groups[1].Value;
+            return true;
+        }
+
+        // Fields starting with < but not matching hoisted pattern → other compiler-generated
+        if (fieldName.StartsWith('<'))
+            return false;
+
+        // Plain name (no angle brackets) → parameter stored with its original name
+        variableName = fieldName;
+        return true;
+    }
+
+    /// <summary>
+    /// Enumerates all fields on the state machine object and returns
+    /// user-visible variables with their unwrapped names.
+    /// </summary>
+    public static List<(string Name, CorDebugValue Value)> UnwrapFields(
+        CorDebugObjectValue stateMachineObj)
+    {
+        var results = new List<(string, CorDebugValue)>();
+
+        // Step 1: Collect field names and tokens
+        var fields = EnumAllFields(stateMachineObj);
+
+        // Step 2: Read values for user-visible fields
+        var classType = stateMachineObj.Class;
+        foreach (var (fieldName, fieldToken) in fields)
+        {
+            if (!TryGetVariableName(fieldName, out var varName))
+                continue;
+
+            try
+            {
+                var value = stateMachineObj.GetFieldValue(classType.Raw, fieldToken);
+                results.Add((varName, value));
+            }
+            catch { }
+        }
+
+        return results;
+    }
+
+    private static List<(string Name, mdFieldDef Token)> EnumAllFields(
+        CorDebugObjectValue objVal)
+    {
+        var results = new List<(string, mdFieldDef)>();
+        var classType = objVal.Class;
+        var module = classType.Module;
+        var import = module.GetMetaDataInterface<MetaDataImport>();
+
+        var enumHandle = IntPtr.Zero;
+        var fieldTokens = new mdFieldDef[64];
+        try
+        {
+            var count = import.EnumFields(ref enumHandle, classType.Token, fieldTokens);
+            for (int i = 0; i < count; i++)
+            {
+                try
+                {
+                    var props = import.GetFieldProps(fieldTokens[i]);
+                    results.Add((props.szField, fieldTokens[i]));
+                }
+                catch { }
+            }
+        }
+        catch { }
+        finally
+        {
+            if (enumHandle != IntPtr.Zero)
+            {
+                try { import.CloseEnum(enumHandle); } catch { }
+            }
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Returns the captured outer "this" (<>4__this field) from the state machine,
+    /// or null if the async method is static.
+    /// </summary>
+    public static CorDebugValue? GetOuterThis(CorDebugObjectValue stateMachineObj)
+    {
+        return MetadataHelper.TryGetField(stateMachineObj, "<>4__this");
+    }
+
+    /// <summary>
+    /// Finds a state machine field matching the given variable name.
+    /// Used by SimpleEvaluator to resolve variable references in async methods.
+    /// </summary>
+    public static CorDebugValue? FindVariable(
+        CorDebugObjectValue stateMachineObj, string variableName)
+    {
+        if (variableName == "this")
+            return GetOuterThis(stateMachineObj);
+
+        var classType = stateMachineObj.Class;
+        var module = classType.Module;
+        var import = module.GetMetaDataInterface<MetaDataImport>();
+
+        var enumHandle = IntPtr.Zero;
+        var fieldTokens = new mdFieldDef[64];
+        try
+        {
+            var count = import.EnumFields(ref enumHandle, classType.Token, fieldTokens);
+            while (count > 0)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    try
+                    {
+                        var props = import.GetFieldProps(fieldTokens[i]);
+                        if (TryGetVariableName(props.szField, out var varName) &&
+                            varName == variableName)
+                        {
+                            return stateMachineObj.GetFieldValue(
+                                classType.Raw, fieldTokens[i]);
+                        }
+                    }
+                    catch { }
+                }
+                count = import.EnumFields(ref enumHandle, classType.Token, fieldTokens);
+            }
+        }
+        finally
+        {
+            if (enumHandle != IntPtr.Zero)
+                import.CloseEnum(enumHandle);
+        }
+
+        return null;
+    }
+}

--- a/debugger/tests/DnD.Core.Tests/StateMachineHelperTests.cs
+++ b/debugger/tests/DnD.Core.Tests/StateMachineHelperTests.cs
@@ -1,0 +1,71 @@
+namespace DnD.Core.Tests;
+
+using DnD.Core.Inspection;
+
+public class StateMachineHelperTests
+{
+    // ── IsStateMachineType ──────────────────────────────────────────
+
+    [Theory]
+    [InlineData("<ProcessAsync>d__3", true)]
+    [InlineData("<Main>d__0", true)]
+    [InlineData("<MoveNext>d__1", true)]
+    [InlineData("<GetDataAsync>d__12", true)]
+    // Nested type in metadata: Namespace.Class/<Method>d__N
+    [InlineData("MyNamespace.MyClass/<ProcessAsync>d__3", true)]
+    // Not state machines
+    [InlineData("MyService", false)]
+    [InlineData("System.String", false)]
+    [InlineData("", false)]
+    // Display class (compiler-generated but not state machine)
+    [InlineData("<>c", false)]
+    [InlineData("<>c__DisplayClass0_0", false)]
+    // Iterator state machine (also uses d__ pattern)
+    [InlineData("<GetItems>d__5", true)]
+    public void IsStateMachineType_DetectsCorrectly(string typeName, bool expected)
+    {
+        Assert.Equal(expected, StateMachineHelper.IsStateMachineType(typeName));
+    }
+
+    // ── TryGetVariableName ──────────────────────────────────────────
+
+    [Theory]
+    // Hoisted local variables: <name>5__N → name
+    [InlineData("<prefix>5__1", "prefix")]
+    [InlineData("<items>5__2", "items")]
+    [InlineData("<result>5__3", "result")]
+    [InlineData("<matchedHub>5__1", "matchedHub")]
+    [InlineData("<longVariableName>5__10", "longVariableName")]
+    // Outer this: <>4__this → this
+    [InlineData("<>4__this", "this")]
+    public void TryGetVariableName_ReturnsName_ForUserVisibleFields(string fieldName, string expectedName)
+    {
+        Assert.True(StateMachineHelper.TryGetVariableName(fieldName, out var name));
+        Assert.Equal(expectedName, name);
+    }
+
+    [Theory]
+    // Internal state machine fields — should be hidden
+    [InlineData("<>1__state")]
+    [InlineData("<>t__builder")]
+    [InlineData("<>u__1")]
+    [InlineData("<>u__2")]
+    // Other compiler-generated fields
+    [InlineData("<>s__1")]
+    [InlineData("<>7__wrap1")]
+    public void TryGetVariableName_ReturnsFalse_ForInternalFields(string fieldName)
+    {
+        Assert.False(StateMachineHelper.TryGetVariableName(fieldName, out _));
+    }
+
+    [Theory]
+    // Plain parameter names (no angle brackets) — returned as-is
+    [InlineData("count", "count")]
+    [InlineData("message", "message")]
+    [InlineData("value", "value")]
+    public void TryGetVariableName_ReturnsName_ForPlainParameters(string fieldName, string expectedName)
+    {
+        Assert.True(StateMachineHelper.TryGetVariableName(fieldName, out var name));
+        Assert.Equal(expectedName, name);
+    }
+}

--- a/debugger/tests/DnD.Host.Tests/AsyncEvalTests.cs
+++ b/debugger/tests/DnD.Host.Tests/AsyncEvalTests.cs
@@ -1,0 +1,124 @@
+namespace DnD.Host.Tests;
+
+using DnD.Protocol;
+using StreamJsonRpc;
+
+/// <summary>
+/// Tests for debugging async methods — verifying that state machine fields
+/// are unwrapped into user-visible variables for getVariables and evaluate.
+/// </summary>
+[Collection("DebugSession")]
+[Trait("Category", "AsyncEval")]
+public class AsyncEvalTests : DebugTestBase
+{
+    // Breakpoint line: Console.WriteLine(result) inside ProcessAsync, after await
+    private const int BreakpointLine = 27;
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        var program = FindFixture("AsyncTest");
+        var sourceFile = FindFixtureSrc("AsyncTest", "Program.cs");
+
+        // Set breakpoint after the await inside ProcessAsync
+        await Rpc!.InvokeWithParameterObjectAsync<SetBreakpointResponse>(
+            "setBreakpoint", new SetBreakpointRequest(File: sourceFile, Line: BreakpointLine));
+
+        // Launch — will hit breakpoint inside state machine's MoveNext
+        await Rpc!.InvokeWithParameterObjectAsync<LaunchResponse>(
+            "launch", new LaunchRequest(Program: program));
+
+        var stopped = WaitForStopped(TimeSpan.FromSeconds(30));
+        Assert.Equal(StopReason.Breakpoint, stopped.Reason);
+
+        // Populate frame map
+        await Rpc!.InvokeWithParameterObjectAsync<GetStackTraceResponse>(
+            "getStackTrace", new GetStackTraceRequest(ThreadId: stopped.ThreadId));
+    }
+
+    // === getVariables ===
+
+    [Fact]
+    public async Task GetVariables_InAsyncMethod_ShowsUnwrappedFields()
+    {
+        var vars = await Rpc!.InvokeWithParameterObjectAsync<GetVariablesResponse>(
+            "getVariables", new GetVariablesRequest());
+
+        var names = vars.Variables.Select(v => v.Name).ToList();
+
+        // Captured parameters should appear with their original names
+        Assert.Contains("count", names);
+        Assert.Contains("message", names);
+
+        // Captured local variables (hoisted from <name>5__N fields) should appear
+        Assert.Contains("prefix", names);
+        Assert.Contains("items", names);
+
+        // Outer this should appear as "this"
+        Assert.Contains("this", names);
+
+        // Internal state machine fields should NOT appear
+        Assert.DoesNotContain("<>1__state", names);
+        Assert.DoesNotContain("<>t__builder", names);
+        // No raw state machine type name
+        Assert.DoesNotContain(names, n => n.Contains(">d__"));
+    }
+
+    // === evaluate: parameters ===
+
+    [Fact]
+    public async Task Evaluate_InAsyncMethod_CapturedIntParameter()
+    {
+        var result = await Rpc!.InvokeWithParameterObjectAsync<EvaluateResponse>(
+            "evaluate", new EvaluateRequest(Expression: "count"));
+
+        Assert.Equal("42", result.Result);
+        Assert.Equal("int", result.Type);
+    }
+
+    [Fact]
+    public async Task Evaluate_InAsyncMethod_CapturedStringParameter()
+    {
+        var result = await Rpc!.InvokeWithParameterObjectAsync<EvaluateResponse>(
+            "evaluate", new EvaluateRequest(Expression: "message"));
+
+        Assert.Equal("\"hello\"", result.Result);
+        Assert.Equal("string", result.Type);
+    }
+
+    // === evaluate: captured locals ===
+
+    [Fact]
+    public async Task Evaluate_InAsyncMethod_CapturedLocal_Prefix()
+    {
+        var result = await Rpc!.InvokeWithParameterObjectAsync<EvaluateResponse>(
+            "evaluate", new EvaluateRequest(Expression: "prefix"));
+
+        Assert.Equal("\"[test-instance]\"", result.Result);
+        Assert.Equal("string", result.Type);
+    }
+
+    [Fact]
+    public async Task Evaluate_InAsyncMethod_CapturedLocal_ItemsCount()
+    {
+        var result = await Rpc!.InvokeWithParameterObjectAsync<EvaluateResponse>(
+            "evaluate", new EvaluateRequest(Expression: "items.Count"));
+
+        Assert.Equal("3", result.Result);
+    }
+
+    // === evaluate: outer this ===
+
+    [Fact]
+    public async Task Evaluate_InAsyncMethod_ThisResolvesToOuterClass()
+    {
+        // In the state machine, "this" should resolve to the MyService instance,
+        // not the state machine struct
+        var result = await Rpc!.InvokeWithParameterObjectAsync<EvaluateResponse>(
+            "evaluate", new EvaluateRequest(Expression: "this._name"));
+
+        Assert.Equal("\"test-instance\"", result.Result);
+        Assert.Equal("string", result.Type);
+    }
+}

--- a/debugger/tests/fixtures/AsyncTest/AsyncTest.csproj
+++ b/debugger/tests/fixtures/AsyncTest/AsyncTest.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/debugger/tests/fixtures/AsyncTest/Program.cs
+++ b/debugger/tests/fixtures/AsyncTest/Program.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var service = new MyService("test-instance");
+        var result = await service.ProcessAsync(42, "hello");
+        Console.WriteLine(result);
+    }
+}
+
+class MyService
+{
+    private string _name;
+
+    public MyService(string name) { _name = name; }
+
+    public async Task<string> ProcessAsync(int count, string message)
+    {
+        var prefix = $"[{_name}]";
+        var items = new List<int> { 1, 2, 3 };
+        await Task.Delay(1);
+        var result = $"{prefix} {message} x{count} items={items.Count}";
+        Console.WriteLine(result);
+        return result;
+    }
+}

--- a/docs/mcp-integration-test-plan.md
+++ b/docs/mcp-integration-test-plan.md
@@ -15,6 +15,7 @@ dotnet build debugger/tests/fixtures/VariablesTest
 dotnet build debugger/tests/fixtures/EvalTest
 dotnet build debugger/tests/fixtures/ExceptionTest
 dotnet build debugger/tests/fixtures/ExitCodeTest
+dotnet build debugger/tests/fixtures/AsyncTest
 
 # TypeScript MCP server
 cd mcp && npm run build
@@ -409,7 +410,48 @@ Verify that Claude autonomously performs:
 5. `launch` -> `continue`
    - Expected: Only hit once so auto-continue -> process exits normally
 
-### 2.19 Exception Breakpoints
+### 2.19 Async Method Debugging
+
+**Purpose**: Verify getVariables and evaluate work correctly inside async state machine methods
+
+**Prerequisite**: Build the AsyncTest fixture:
+```bash
+dotnet build debugger/tests/fixtures/AsyncTest
+```
+
+**Steps**:
+1. `setBreakpoint` at AsyncTest Program.cs:27 (Console.WriteLine inside ProcessAsync, after await)
+2. `launch` AsyncTest fixture
+   - Expected: `Stopped: breakpoint #1` inside `MoveNext` of `ProcessAsync`
+3. `getVariables`
+   - Expected: Unwrapped state machine fields as user-visible variables:
+     - `count: int = 42` (captured parameter)
+     - `message: string = "hello"` (captured parameter)
+     - `prefix: string = "[test-instance]"` (hoisted local)
+     - `items: List<int>` (hoisted local)
+     - `this: MyService` (outer class instance via `<>4__this`)
+   - Internal fields (`<>1__state`, `<>t__builder`, `<>u__1`) must NOT appear
+4. `evaluate("count")`
+   - Expected: `42 (int)`
+5. `evaluate("message")`
+   - Expected: `"hello" (string)`
+6. `evaluate("prefix")`
+   - Expected: `"[test-instance]" (string)`
+7. `evaluate("items.Count")`
+   - Expected: `3 (int)`
+8. `evaluate("this._name")`
+   - Expected: `"test-instance" (string)` — accesses outer class private field
+9. `terminate` to exit
+
+**Verification Points**:
+- State machine fields are unwrapped into original variable names
+- Internal compiler-generated fields are hidden
+- Parameters captured by the state machine are accessible by their original names
+- Hoisted local variables are accessible by their original names
+- `this` resolves to the outer class instance, not the state machine struct
+- Expression evaluation works on captured variables (both simple and Roslyn paths)
+
+### 2.20 Exception Breakpoints
 
 **Purpose**: Verify exception filtering with setExceptionBreakpoints
 
@@ -478,8 +520,14 @@ Verify that Claude autonomously performs:
 | 45 | Exception BP | thrown+uncaught, no filter -> stops |
 | 46 | Exception BP | types=["ArgumentException"], InvalidOp -> skipped |
 | 47 | Exception BP | types=["InvalidOperation"], InvalidOp -> stops |
-| 48 | E2E | Claude autonomously completes a debug session |
-| 49 | E2E | Claude autonomously completes an exception debug session |
+| 48 | Async | getVariables unwraps state machine fields |
+| 49 | Async | Internal fields (<>1__state, etc.) are hidden |
+| 50 | Async | Captured parameters accessible (count, message) |
+| 51 | Async | Hoisted locals accessible (prefix, items) |
+| 52 | Async | `this` resolves to outer class, not state machine |
+| 53 | Async | evaluate works on captured variables |
+| 54 | E2E | Claude autonomously completes a debug session |
+| 55 | E2E | Claude autonomously completes an exception debug session |
 
 ---
 

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dnd-mcp",
-  "version": "0.2.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dnd-mcp",
-      "version": "0.2.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "os": [
         "win32"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnd-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MCP server for DnD .NET debugger — debug C# programs via MCP",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- **Async state machine variable unwrapping**: `getVariables` and `evaluate` now work correctly inside `async` methods. State machine fields are unwrapped into original variable names, internal compiler-generated fields are hidden, and `this` resolves to the outer class instance.

## Changes

### Async state machine support (new)
- `StateMachineHelper` detects `<Method>d__N` types and maps fields:
  - `<name>5__N` → `name` (hoisted locals)
  - `<>4__this` → `this` (outer class instance)
  - `<>1__state`, `<>t__builder`, `<>u__N` → hidden (internal)
- `GetFrameVariables` unwraps state machine fields instead of showing raw `this: <Method>d__N`
- `SimpleEvaluator` falls back to state machine field lookup
- `RoslynEvaluator` replaces state machine `this` with outer class and injects hoisted fields as locals
- `NeedsObjectParameter` treats types containing `<` as requiring `object` parameter (safety net)

### Tests
- `StateMachineHelperTests` (26 unit tests): type name detection, field name parsing
- `AsyncEvalTests` (6 integration tests): getVariables unwrapping, evaluate for params/locals/this
- `AsyncTest` fixture: async method with captured parameters, locals, and outer `this`

### Docs
- E2E test plan: added Scenario 2.19 (Async Method Debugging), checklist items #48-53

### Version
- npm package bumped to 0.4.0

## Commits (since v0.3.0)

- `e53bb2e` chore: bump version to 0.4.0
- `0c94cbb` feat: unwrap async state machine fields for getVariables and evaluate

## Test verification

- Unit tests: 118 pass (including 26 new StateMachineHelper tests)
- Integration tests: 307 pass (including 6 new AsyncEval tests)
- E2E: all 17 scenarios pass (including new Scenario 2.19)